### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tiktoken
 numpy
 openpyxl
 PyQt5
-"PyQt-Fluent-Widgets[full]"
+PyQt-Fluent-Widgets[full]
 opencc
 google-generativeai
 pandas


### PR DESCRIPTION
去掉依赖`PyQt-Fluent-Widgets[full]`的引号

否则执行`pip install -r ./requirements.txt`会报错：

```
ERROR: Invalid requirement: '"PyQt-Fluent-Widgets[full]"' (from line 9 of requirements.txt)
```