### PR TITLE
[REPOST] 调整 - Token 限制模式下，SakuraLLM 请求的最大tokens数应该与应用设置保持一致

### DIFF
--- a/AiNiee.py
+++ b/AiNiee.py
@@ -2072,7 +2072,7 @@ class Api_Requester():
 
 
                     extra_query = {
-                        'do_sample': False,
+                        'do_sample': True,
                         'num_beams': 1,
                         'repetition_penalty': 1.0,
                     }
@@ -2082,21 +2082,25 @@ class Api_Requester():
                     # 获取请求地址
                     openai_base_url = configurator.base_url
                     # 创建openai客户端
-                    openaiclient = OpenAI(api_key=openai_apikey,
-                                            base_url= openai_base_url)
+                    openaiclient = OpenAI(api_key = openai_apikey, base_url = openai_base_url)
+                    # Token限制模式下，请求的最大tokens数应该与设置保持一致
+                    if not configurator.tokens_limit_switch:
+                        openai_max_tokens = 512
+                    else:
+                        openai_max_tokens = max(0, configurator.tokens_limit)
+                    
                     # 发送对话请求
                     try:
                         response = openaiclient.chat.completions.create(
-                            model= configurator.model_type,
-                            messages = messages ,
-                            temperature=temperature,
+                            model = configurator.model_type,
+                            messages = messages,
+                            temperature = temperature,
                             top_p = top_p,                        
-                            frequency_penalty=frequency_penalty,
-
-                            max_tokens=512,
-                            seed=-1,
-                            extra_query=extra_query,
-                            )
+                            frequency_penalty = frequency_penalty,
+                            max_tokens = openai_max_tokens,
+                            seed = -1,
+                            extra_query = extra_query,
+                        )
 
                     #抛出错误信息
                     except Exception as e:


### PR DESCRIPTION
现在的代码中请求的 max_tokens 是固定值 512，这个修改解决两个问题：

1、用户设置较小的token阈值时
在少数特定情况下，比如模型出现退化或者幻觉时，回复会撑爆这里设置的值
这个时候，如果服务器端ctx设置的较低（以配合应用内较低的token限制值），就会撑爆上下文，导致翻译缓慢或者结果异常

2、用户设置设置较大的token阈值时
翻译结果只会输出512个token，导致结果被截断，无法通过校验，翻译失败

通过同步调整，确保只要应用内token数阈值不超过服务器端ctx的1/2，那么就一定不会撑爆上下文