### PR TITLE
為 OpenCC 新增配置文件設定

### DIFF
--- a/AiNiee.py
+++ b/AiNiee.py
@@ -301,15 +301,14 @@ class Translator():
             
 
         #如果开启了转换简繁开关功能，则进行文本转换
-        if configurator.conversion_toggle: 
-            if configurator.target_language == "简中" or configurator.target_language == "繁中":
-                try:
-                    configurator.cache_list = Cache_Manager.simplified_and_traditional_conversion(self,configurator.cache_list, configurator.target_language)
-                    print(f"\033[1;32mSuccess:\033[0m  文本转化{configurator.target_language}完成-----------------------------------", '\n')   
+        if configurator.conversion_toggle:
+            try:
+                configurator.cache_list = Cache_Manager.simplified_and_traditional_conversion(self,configurator.cache_list, configurator.opencc_preset)
+                print(f"\033[1;32mSuccess:\033[0m  文本转化{configurator.target_language}完成-----------------------------------", '\n')   
 
-                except Exception as e:
-                    print("\033[1;33mWarning:\033[0m 文本转换出现问题！！将跳过该步，错误信息如下")
-                    print(f"Error: {e}\n")
+            except Exception as e:
+                print("\033[1;33mWarning:\033[0m 文本转换出现问题！！将跳过该步，错误信息如下")
+                print(f"Error: {e}\n")
 
         # 将翻译结果写为对应文件
         File_Outputter.output_translated_content(self,configurator.cache_list,configurator.Output_Folder,configurator.Input_Folder)
@@ -2652,6 +2651,7 @@ class User_Interface_Prompter(QObject):
             config_dict["translation_platform"] = Window.Widget_translation_settings_A.comboBox_translation_platform.currentText()
             config_dict["source_language"] = Window.Widget_translation_settings_A.comboBox_source_text.currentText()
             config_dict["target_language"] = Window.Widget_translation_settings_A.comboBox_translated_text.currentText()
+            config_dict["opencc_preset"] = Window.Widget_translation_settings_A.comboBox_opencc_preset.currentText()
             config_dict["label_input_path"] = Window.Widget_translation_settings_A.label_input_path.text()
             config_dict["label_output_path"] = Window.Widget_translation_settings_A.label_output_path.text()
 
@@ -3048,6 +3048,8 @@ class User_Interface_Prompter(QObject):
                     Window.Widget_translation_settings_A.comboBox_source_text.setCurrentText(config_dict["source_language"])
                 if "target_language" in config_dict:
                     Window.Widget_translation_settings_A.comboBox_translated_text.setCurrentText(config_dict["target_language"])
+                if "opencc_preset" in config_dict:
+                    Window.Widget_translation_settings_A.comboBox_opencc_preset.setCurrentText(config_dict["opencc_preset"])
                 if "label_input_path" in config_dict:
                     Window.Widget_translation_settings_A.label_input_path.setText(config_dict["label_input_path"])
                 if "label_output_path" in config_dict:

--- a/Module_Folders/Cache_Manager/Cache.py
+++ b/Module_Folders/Cache_Manager/Cache.py
@@ -600,7 +600,7 @@ class Cache_Manager():
 
 
     # 将缓存文件里已翻译的文本转换为简体字或繁体字
-    def simplified_and_traditional_conversion( self,cache_list, target_language):
+    def simplified_and_traditional_conversion(self,cache_list, opencc_preset):
         # 缓存数据结构示例
         ex_cache_data = [
         {'project_type': 'Mtool'},
@@ -611,10 +611,7 @@ class Cache_Manager():
         ]    
 
         # 确定使用的转换器
-        if target_language == "简中": 
-            cc = opencc.OpenCC('t2s')  # 创建OpenCC对象，使用t2s参数表示繁体字转简体字
-        elif target_language == "繁中": 
-            cc = opencc.OpenCC('s2t')
+        cc = opencc.OpenCC(opencc_preset)  # 创建OpenCC对象，使用t2s参数表示繁体字转简体字
 
         # 存储结果的列表
         converted_list = []

--- a/Module_Folders/Configurator/Config.py
+++ b/Module_Folders/Configurator/Config.py
@@ -205,6 +205,7 @@ class Configurator():
         self.translation_platform = config_dict["translation_platform"]
         self.source_language = config_dict["source_language"]
         self.target_language = config_dict["target_language"]
+        self.opencc_preset = config_dict["opencc_preset"]
         self.Input_Folder = config_dict["label_input_path"]
         self.Output_Folder = config_dict["label_output_path"]
 

--- a/User_Interface/Translation_Settings_Interface/Interface_translation_settings_A.py
+++ b/User_Interface/Translation_Settings_Interface/Interface_translation_settings_A.py
@@ -170,7 +170,30 @@ class Widget_translation_settings_A(QFrame):#  基础设置子界面
         box_translated_text.setLayout(layout_translated_text)
 
 
-        # -----创建第6个组，添加多个组件-----
+        # -----创建第6个组(后面添加的)，添加多个组件-----
+        box_opencc_preset = QGroupBox()
+        box_opencc_preset.setStyleSheet(""" QGroupBox {border: 1px solid lightgray; border-radius: 8px;}""")  # 分别设置了边框大小，边框颜色，边框圆角
+        layout_opencc_preset = QHBoxLayout()
+
+
+        #设置“OpenCC 配置”标签
+        label3_2 = QLabel(parent=self, flags=Qt.WindowFlags())  
+        label3_2.setStyleSheet("font-family: 'Microsoft YaHei'; font-size: 17px;  color: black")
+        label3_2.setText("OpenCC 配置")
+
+        #设置“OpenCC 配置”下拉选择框
+        self.comboBox_opencc_preset = ComboBox()  # 以demo为父类
+        self.comboBox_opencc_preset.addItems(['s2t', 't2s', 's2tw', 'tw2s', 's2hk', 'hk2s', 's2twp', 'tw2sp', 't2tw', 'hk2t', 't2hk', 't2jp', 'jp2t', 'tw2t'])
+        self.comboBox_opencc_preset.setCurrentIndex(0)  # 设置下拉框控件（ComboBox）的当前选中项的索引为 0，也就是默认选中第一个选项
+        self.comboBox_opencc_preset.setFixedSize(127, 30)
+
+
+        layout_opencc_preset.addWidget(label3_2)
+        layout_opencc_preset.addWidget(self.comboBox_opencc_preset)
+        box_opencc_preset.setLayout(layout_opencc_preset)
+
+
+        # -----创建第7个组，添加多个组件-----
         box_save = QGroupBox()
         box_save.setStyleSheet(""" QGroupBox {border: 0px solid lightgray; border-radius: 8px;}""")#分别设置了边框大小，边框颜色，边框圆角
         layout_save = QHBoxLayout()
@@ -198,6 +221,7 @@ class Widget_translation_settings_A(QFrame):#  基础设置子界面
         container.addWidget(box_translation_platform)
         container.addWidget(box_source_text)
         container.addWidget(box_translated_text)
+        container.addWidget(box_opencc_preset)
         container.addWidget(box_input)
         container.addWidget(box_output)
         container.addWidget(box_save)


### PR DESCRIPTION
很感謝 NEKOparapa 大佬開發的 AiNiee 工具，真的是用過最順手的遊戲文本翻譯工具。

但目前在使用上有個關於簡繁轉換的小問題。
主要的原因在於 AiNiee 套用了 OpenCC 的套件，但在簡轉繁時預設使用了 `s2t` 這個配置。
該配置在不少情況下都會翻譯出比較不符合該地區的用語。
例如在 #182 中提到的 `剛纔`、`爲了`、`數據庫`、`背地裏` 以及 `穿着` 等用語。

我自己實測下來，前述的用語使用 `s2tw` 配置都能夠被正確轉換。 (`剛才`、`為了`、`資料庫`、`背地裡`、`穿著`)
因此我認為如果能夠加入 OpenCC 的配置文件的設定應該能有效解決這個問題，故著手進行這個 PR。

在修改的時候我有進行幾個邏輯上的改動:
1. 因為 OpenCC 中不只有簡繁中文的配置，因此我將是否套用 OpenCC 的邏輯去除了 `configurator.target_language == "简中" or configurator.target_language == "繁中"` 這個判斷式。
2. 修改 `simplified_and_traditional_conversion` 的時候因為不再透過 `configurator.target_language` 來判斷，並且需要傳入 `configurator.opencc_preset` 參數，故在 `simplified_and_traditional_conversion` 的參數簽名中有所調整。