### PR TITLE
調整 OpenCC 配置至專項頁面

### DIFF
--- a/AiNiee.py
+++ b/AiNiee.py
@@ -2651,7 +2651,6 @@ class User_Interface_Prompter(QObject):
             config_dict["translation_platform"] = Window.Widget_translation_settings_A.comboBox_translation_platform.currentText()
             config_dict["source_language"] = Window.Widget_translation_settings_A.comboBox_source_text.currentText()
             config_dict["target_language"] = Window.Widget_translation_settings_A.comboBox_translated_text.currentText()
-            config_dict["opencc_preset"] = Window.Widget_translation_settings_A.comboBox_opencc_preset.currentText()
             config_dict["label_input_path"] = Window.Widget_translation_settings_A.label_input_path.text()
             config_dict["label_output_path"] = Window.Widget_translation_settings_A.label_output_path.text()
 
@@ -2668,6 +2667,7 @@ class User_Interface_Prompter(QObject):
             config_dict["cn_prompt_toggle"] =  Window.Widget_translation_settings_B2.SwitchButton_cn_prompt_toggle.isChecked()   # 获取中文提示词开关
             config_dict["preserve_line_breaks_toggle"] =  Window.Widget_translation_settings_B2.SwitchButton_line_breaks.isChecked() # 获取保留换行符开关  
             config_dict["response_conversion_toggle"] =  Window.Widget_translation_settings_B2.SwitchButton_conversion_toggle.isChecked()   # 获取简繁转换开关
+            config_dict["opencc_preset"] = Window.Widget_translation_settings_B2.comboBox_opencc_preset.currentText()
             config_dict["text_clear_toggle"] =  Window.Widget_translation_settings_B2.SwitchButton_clear.isChecked() # 获取文本处理开关
 
             #翻译设置的检查设置页面
@@ -3048,8 +3048,6 @@ class User_Interface_Prompter(QObject):
                     Window.Widget_translation_settings_A.comboBox_source_text.setCurrentText(config_dict["source_language"])
                 if "target_language" in config_dict:
                     Window.Widget_translation_settings_A.comboBox_translated_text.setCurrentText(config_dict["target_language"])
-                if "opencc_preset" in config_dict:
-                    Window.Widget_translation_settings_A.comboBox_opencc_preset.setCurrentText(config_dict["opencc_preset"])
                 if "label_input_path" in config_dict:
                     Window.Widget_translation_settings_A.label_input_path.setText(config_dict["label_input_path"])
                 if "label_output_path" in config_dict:
@@ -3082,6 +3080,8 @@ class User_Interface_Prompter(QObject):
                     Window.Widget_translation_settings_B2.SwitchButton_line_breaks.setChecked(config_dict["preserve_line_breaks_toggle"])
                 if "response_conversion_toggle" in config_dict:
                     Window.Widget_translation_settings_B2.SwitchButton_conversion_toggle.setChecked(config_dict["response_conversion_toggle"])
+                if "opencc_preset" in config_dict:
+                    Window.Widget_translation_settings_B2.comboBox_opencc_preset.setCurrentText(config_dict["opencc_preset"])
                 if "text_clear_toggle" in config_dict:
                     Window.Widget_translation_settings_B2.SwitchButton_clear.setChecked(config_dict["text_clear_toggle"])
 

--- a/Module_Folders/Configurator/Config.py
+++ b/Module_Folders/Configurator/Config.py
@@ -205,7 +205,6 @@ class Configurator():
         self.translation_platform = config_dict["translation_platform"]
         self.source_language = config_dict["source_language"]
         self.target_language = config_dict["target_language"]
-        self.opencc_preset = config_dict["opencc_preset"]
         self.Input_Folder = config_dict["label_input_path"]
         self.Output_Folder = config_dict["label_output_path"]
 
@@ -226,6 +225,7 @@ class Configurator():
         self.text_clear_toggle = config_dict["text_clear_toggle"]
         self.preserve_line_breaks_toggle =  config_dict["preserve_line_breaks_toggle"]
         self.conversion_toggle = config_dict["response_conversion_toggle"]
+        self.opencc_preset = config_dict["opencc_preset"]
 
         # 检查设置页面
         self.reply_check_switch = config_dict["reply_check_switch"]

--- a/User_Interface/Translation_Settings_Interface/Interface_translation_settings_A.py
+++ b/User_Interface/Translation_Settings_Interface/Interface_translation_settings_A.py
@@ -170,30 +170,7 @@ class Widget_translation_settings_A(QFrame):#  基础设置子界面
         box_translated_text.setLayout(layout_translated_text)
 
 
-        # -----创建第6个组(后面添加的)，添加多个组件-----
-        box_opencc_preset = QGroupBox()
-        box_opencc_preset.setStyleSheet(""" QGroupBox {border: 1px solid lightgray; border-radius: 8px;}""")  # 分别设置了边框大小，边框颜色，边框圆角
-        layout_opencc_preset = QHBoxLayout()
-
-
-        #设置“OpenCC 配置”标签
-        label3_2 = QLabel(parent=self, flags=Qt.WindowFlags())  
-        label3_2.setStyleSheet("font-family: 'Microsoft YaHei'; font-size: 17px;  color: black")
-        label3_2.setText("OpenCC 配置")
-
-        #设置“OpenCC 配置”下拉选择框
-        self.comboBox_opencc_preset = ComboBox()  # 以demo为父类
-        self.comboBox_opencc_preset.addItems(['s2t', 't2s', 's2tw', 'tw2s', 's2hk', 'hk2s', 's2twp', 'tw2sp', 't2tw', 'hk2t', 't2hk', 't2jp', 'jp2t', 'tw2t'])
-        self.comboBox_opencc_preset.setCurrentIndex(0)  # 设置下拉框控件（ComboBox）的当前选中项的索引为 0，也就是默认选中第一个选项
-        self.comboBox_opencc_preset.setFixedSize(127, 30)
-
-
-        layout_opencc_preset.addWidget(label3_2)
-        layout_opencc_preset.addWidget(self.comboBox_opencc_preset)
-        box_opencc_preset.setLayout(layout_opencc_preset)
-
-
-        # -----创建第7个组，添加多个组件-----
+        # -----创建第6个组，添加多个组件-----
         box_save = QGroupBox()
         box_save.setStyleSheet(""" QGroupBox {border: 0px solid lightgray; border-radius: 8px;}""")#分别设置了边框大小，边框颜色，边框圆角
         layout_save = QHBoxLayout()
@@ -221,7 +198,6 @@ class Widget_translation_settings_A(QFrame):#  基础设置子界面
         container.addWidget(box_translation_platform)
         container.addWidget(box_source_text)
         container.addWidget(box_translated_text)
-        container.addWidget(box_opencc_preset)
         container.addWidget(box_input)
         container.addWidget(box_output)
         container.addWidget(box_save)

--- a/User_Interface/Translation_Settings_Interface/Interface_translation_settings_B2.py
+++ b/User_Interface/Translation_Settings_Interface/Interface_translation_settings_B2.py
@@ -107,6 +107,30 @@ class Widget_translation_settings_B2(QFrame):#  专项设置子界面
 
 
         # -----创建第4个组(后来补的)，添加多个组件-----
+        box_opencc_preset = QGroupBox()
+        box_opencc_preset.setStyleSheet(""" QGroupBox {border: 1px solid lightgray; border-radius: 8px;}""")  # 分别设置了边框大小，边框颜色，边框圆角
+        layout_opencc_preset = QHBoxLayout()
+
+
+        #设置“OpenCC 配置”标签
+        labe1_7 = QLabel(parent=self, flags=Qt.WindowFlags())  
+        labe1_7.setStyleSheet("font-family: 'Microsoft YaHei'; font-size: 17px;  color: black")
+        labe1_7.setText("OpenCC 配置")
+
+        #设置“OpenCC 配置”下拉选择框
+        self.comboBox_opencc_preset = ComboBox()  # 以demo为父类
+        self.comboBox_opencc_preset.addItems(['s2t', 't2s', 's2tw', 'tw2s', 's2hk', 'hk2s', 's2twp', 'tw2sp', 't2tw', 'hk2t', 't2hk', 't2jp', 'jp2t', 'tw2t'])
+        self.comboBox_opencc_preset.setCurrentIndex(0)  # 设置下拉框控件（ComboBox）的当前选中项的索引为 0，也就是默认选中第一个选项
+        self.comboBox_opencc_preset.setFixedSize(127, 30)
+
+
+        layout_opencc_preset.addWidget(labe1_7)
+        layout_opencc_preset.addWidget(self.comboBox_opencc_preset)
+        box_opencc_preset.setLayout(layout_opencc_preset)
+
+
+
+        # -----创建第5个组(后来补的)，添加多个组件-----
         box1_line_breaks = QGroupBox()
         box1_line_breaks.setStyleSheet(""" QGroupBox {border: 1px solid lightgray; border-radius: 8px;}""")#分别设置了边框大小，边框颜色，边框圆角
         layout1_line_breaks = QHBoxLayout()
@@ -138,6 +162,7 @@ class Widget_translation_settings_B2(QFrame):#  专项设置子界面
         container.addWidget(box1_cn_prompt_toggle)
         container.addWidget(box1_line_breaks)
         container.addWidget(box1_conversion_toggle)
+        container.addWidget(box_opencc_preset)
         container.addWidget(box_clear)
         container.addStretch(1)  # 添加伸缩项
 


### PR DESCRIPTION
根據 #236 中的建議，將 `OpenCC 配置` 的設定項目移至 `专项页面` 中的 `简繁转换开关` 下面。