### PR TITLE
fix docx reader and writer for empty tag

### DIFF
--- a/ModuleFolders/FileOutputer/DocxWriter.py
+++ b/ModuleFolders/FileOutputer/DocxWriter.py
@@ -104,7 +104,7 @@ class DocxWriter():
             # 根据 w:t 标签找到原文
             paragraphs = xml_soup.findAll('w:t')
             for match in paragraphs:
-                if match.string.strip():
+                if isinstance(match.string, str) and match.string.strip():
                     # 在翻译结果中查找是否存在原文，存在则替换并右移开始下标
                     for content_index in range(start_index, len(content_list)):
                         if match.string == content_list[content_index]['source_text']:

--- a/ModuleFolders/FileReader/DocxReader.py
+++ b/ModuleFolders/FileReader/DocxReader.py
@@ -62,7 +62,7 @@ class DocxReader():
                     paragraphs = xml_soup.findAll('w:t')
 
                     # 过滤掉空的内容
-                    filtered_matches = [match.string for match in paragraphs if match.string .strip()]
+                    filtered_matches = [match.string for match in paragraphs if isinstance(match.string, str) and match.string.strip()]
 
                     # 遍历每个标签，并提取文本内容
                     for text in filtered_matches:


### PR DESCRIPTION
对于一些转换出来的docx文件，可能存在空的<w:t>标签，即<w:t></w:t>，该修改是检查改标签内容是否为str及其派生类，保证执行.strip()不会报错退出。