### PR TITLE
fix: 增强多行文本块内容提取健壮性

### DIFF
--- a/ModuleFolders/FileReader/TransReader.py
+++ b/ModuleFolders/FileReader/TransReader.py
@@ -47,7 +47,7 @@ class TransReader:
                         rowInfoText = None
                         if idx < len(parameters_list):
                             parameters = parameters_list[idx]
-                            if parameters:
+                            if parameters and len(parameters) > 0 and isinstance(parameters[0], dict):
                                 rowInfoText = parameters[0].get("rowInfoText", "")  # 可能为 具体人名 或类似 "\\v[263]" 的字符串
 
                         entry_data = {

--- a/ModuleFolders/FileReader/TransReader.py
+++ b/ModuleFolders/FileReader/TransReader.py
@@ -49,7 +49,7 @@ class TransReader(BaseSourceReader):
                 rowInfoText = None
                 if idx < len(parameters_list):
                     parameters = parameters_list[idx]
-                    if parameters:
+                    if parameters and len(parameters) > 0 and isinstance(parameters[0], dict):
                         rowInfoText = parameters[0].get("rowInfoText", "")  # 可能为 具体人名 或类似 "\\v[263]" 的字符串
 
                 item = text_to_cache_item(source_text, translated_text)


### PR DESCRIPTION
## 问题描述

在当前的实现中，`extract_text_to_dict`函数依赖逗号作为列表项的分隔符。然而，在实际使用中发现AI生成的内容偶尔（ds貌似比较频繁）会省略逗号，导致 **多行文本块中** 多个独立项被错误地合并为一个。

例如，以下内容应该被解析为两个独立的项目：
```
"2.2.我向自己发誓，在我与罗亚的联系消失之前，"
"2.1.即便失去力量，我也要找到纠正错误的方法。"
```

但由于缺少逗号分隔，当前实现会将其视为一个单一项目。

## 改进方案

增加了一种新的判断机制：除了检查逗号或内容结尾外，还检查是否存在形如`"n.n.`的编号模式作为新项目的开始标志。这样即使缺少逗号，也能正确识别并分割项目。

## 测试结果

**改进前**：
```
输入:
"2.2.我向自己发誓，在我与罗亚的联系消失之前，"
"2.1.即便失去力量，我也要找到纠正错误的方法。"
结果: 
0: 2.2.我向自己发誓，在我与罗亚的联系消失之前，" "2.1.即便失去力量，我也要找到纠正错误的方法。
```

**改进后**：
```
输入:
"2.2.我向自己发誓，在我与罗亚的联系消失之前，"
"2.1.即便失去力量，我也要找到纠正错误的方法。"
结果:
0: 2.2.我向自己发誓，在我与罗亚的联系消失之前，
1: 2.1.即便失去力量，我也要找到纠正错误的方法。
```