### PR TITLE
修复rich table不显示[]内容问题

### DIFF
--- a/ModuleFolders/Translator/TranslatorTask.py
+++ b/ModuleFolders/Translator/TranslatorTask.py
@@ -7,6 +7,7 @@ import itertools
 import rapidjson as json
 from rich import box
 from rich.table import Table
+from rich.markup import escape
 from typing import List, Tuple
 
 from Base.Base import Base
@@ -674,7 +675,7 @@ class TranslatorTask(Base):
 
         for row in rows:
             if isinstance(row, str):
-                table.add_row(row)
+                table.add_row(escape(row, re.compile(r"(\\*)(\[(?!bright_blue\]|\/\])[a-z#/@][^[]*?)").sub))
             else:
                 table.add_row(*row)
 


### PR DESCRIPTION
在generate_log_table的table.add_row增加了escape
为防止原有bright_blue参数失效，过滤了[bright_blue]和[/]
这个方法是在不大改代码下比较好的实现方法，
缺点是如果你以后要新增参数并使用generate_log_table输出，需要额外过滤一下新增的参数
好处就不必多说，所有[]内容正常输出