### PR TITLE
perf(ResponseExtractor): 完善提取序号与正文的正则，尝试去除多余的序号

### DIFF
--- a/ModuleFolders/FileReader/MdReader.py
+++ b/ModuleFolders/FileReader/MdReader.py
@@ -27,7 +27,7 @@ class MdReader(BaseSourceReader):
         return "md"
 
     def read_source_file(self, file_path: Path, detected_encoding: str) -> list[CacheItem]:
-        items = self.txt_reader.read_source_file(file_path, cache_project)
+        items = self.txt_reader.read_source_file(file_path, detected_encoding)
         for item in items:
             item.original_line = item.get_source_text()
         return items

--- a/ModuleFolders/FileReader/OfficeConversionReader.py
+++ b/ModuleFolders/FileReader/OfficeConversionReader.py
@@ -41,7 +41,7 @@ class OfficeConversionReader(BaseSourceReader):
         if self.converter.can_convert(file_path, tmp_docx_path):
             if not tmp_docx_path.exists():
                 self.converter.convert_file(file_path, tmp_docx_path)
-            return self.docx_reader.read_source_file(tmp_docx_path, cache_project)
+            return self.docx_reader.read_source_file(tmp_docx_path, detected_encoding)
         return []
 
 

--- a/ModuleFolders/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/PromptBuilder/PromptBuilder.py
@@ -162,7 +162,7 @@ class PromptBuilder(Base):
                     numbered_text = f"{index + 1}.[\n"
                     total_lines = len(lines)
                     for sub_index, sub_line in enumerate(lines):
-                        numbered_text += f""""{index + 1}.{total_lines - sub_index}.,{sub_line}",\n"""
+                        numbered_text += f'"{index + 1}.{total_lines - sub_index}.,{sub_line}",\n'
                     numbered_text = numbered_text.rstrip('\n')
                     numbered_text = numbered_text.rstrip(',')
                     numbered_text += f"\n]"  # 用json.dumps会影响到原文的转义字符
@@ -183,7 +183,7 @@ class PromptBuilder(Base):
                     numbered_text = f"{index + 1}.[\n"
                     total_lines = len(lines)
                     for sub_index, sub_line in enumerate(lines):
-                        numbered_text += f""""{index + 1}.{total_lines - sub_index}.,{sub_line}",\n"""
+                        numbered_text += f'"{index + 1}.{total_lines - sub_index}.,{sub_line}",\n'
                     numbered_text = numbered_text.rstrip('\n')
                     numbered_text = numbered_text.rstrip(',')
                     numbered_text += f"\n]"  # 用json.dumps会影响到原文的转义字符

--- a/ModuleFolders/ResponseExtractor/ResponseExtractor.py
+++ b/ModuleFolders/ResponseExtractor/ResponseExtractor.py
@@ -16,11 +16,11 @@ class ResponseExtractor:
     multiline_quote_suffix = r'(?:\n["“”][,，]|["“”]\n[,，]|["“”]?[,，]?)$'
 
     # 判断多行文本开始的正则
-    multiline_start_reg = re.compile(fr'^\s*["“”]\s*{multiline_number_prefix}')
+    multiline_start_reg = re.compile(rf'^\s*["“”]\s*{multiline_number_prefix}')
     # 提取多行文本边界的正则
-    boundary_pattern_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}')
+    boundary_pattern_reg = re.compile(f'["“”][^"“”]*?{multiline_number_prefix}')
     # 提取规范数字序号与正文的正则
-    extract_num_text_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}(.*?){multiline_quote_suffix}')
+    extract_num_text_reg = re.compile(f'["“”][^"“”]*?{multiline_number_prefix}(.*?){multiline_quote_suffix}')
 
     def __init__(self):
         pass

--- a/ModuleFolders/ResponseExtractor/ResponseExtractor.py
+++ b/ModuleFolders/ResponseExtractor/ResponseExtractor.py
@@ -18,7 +18,9 @@ class ResponseExtractor():
     # 提取多行文本边界的正则
     boundary_pattern_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}')
     # 提取规范数字序号与正文的正则
-    extract_num_text_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}(.*?)["“”]?[,，]?$')
+    extract_num_text_reg = re.compile(
+        fr'["“”][^"“”]*?{multiline_number_prefix}(.*?)(?:\n["“”][,，]|["“”]\n[,，]|["“”]?[,，]?)$'
+    )
 
     def __init__(self):
         pass
@@ -204,8 +206,10 @@ class ResponseExtractor():
 
                     # 确保两个组都被成功捕获
                     if number_part is not None and text_part is not None:
+                        # 去除`text_part`中可能出现的`number_part`
+                        cleaned_text_part = text_part.replace(number_part, '').replace(number_part.rstrip('.'), '')
                         # 组合数字和文本，保留匹配到的 `text_part` 原始文本
-                        assembled_content = f"{number_part},{text_part}"
+                        assembled_content = f"{number_part},{cleaned_text_part}"
                         result.append(assembled_content)
                     else:
                         # 更详细地指明哪个部分为空

--- a/ModuleFolders/ResponseExtractor/ResponseExtractor.py
+++ b/ModuleFolders/ResponseExtractor/ResponseExtractor.py
@@ -7,20 +7,20 @@ from rich.markup import escape
 
 
 # 回复解析器
-class ResponseExtractor():
+class ResponseExtractor:
 
     # 多行文本数字匹配格式
     # 目前有两个匹配组，第一个为标准数字序号部分，第二个为可能出现的多余引号组（常见于deepseek-v3）
     multiline_number_prefix = r'(\d+\.\d+\.)(")?[,，\s]?(?(2)"|)?'
+    # 多行文本段结束后缀
+    multiline_quote_suffix = r'(?:\n["“”][,，]|["“”]\n[,，]|["“”]?[,，]?)$'
 
     # 判断多行文本开始的正则
     multiline_start_reg = re.compile(fr'^\s*["“”]\s*{multiline_number_prefix}')
     # 提取多行文本边界的正则
     boundary_pattern_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}')
     # 提取规范数字序号与正文的正则
-    extract_num_text_reg = re.compile(
-        fr'["“”][^"“”]*?{multiline_number_prefix}(.*?)(?:\n["“”][,，]|["“”]\n[,，]|["“”]?[,，]?)$'
-    )
+    extract_num_text_reg = re.compile(fr'["“”][^"“”]*?{multiline_number_prefix}(.*?){multiline_quote_suffix}')
 
     def __init__(self):
         pass

--- a/ModuleFolders/Translator/TranslatorTask.py
+++ b/ModuleFolders/Translator/TranslatorTask.py
@@ -265,7 +265,7 @@ class TranslatorTask(Base):
                     # 不去除空白内容，保留\r其他平台的换行符，虽然AI回复不一定保留...
                     # 仅当 **只有一个** 尾随空格时才去除
                     sub_line = sub_line[:-1] if re.match(r'.*[^ ] $', sub_line) else sub_line
-                    numbered_text += f""""{index + 1}.{total_lines - sub_index}.,{sub_line}",\n"""
+                    numbered_text += f'"{index + 1}.{total_lines - sub_index}.,{sub_line}",\n'
                 numbered_text = numbered_text.rstrip('\n')
                 numbered_text = numbered_text.rstrip(',')
                 numbered_text += f"\n]"  # 用json.dumps会影响到原文的转义字符
@@ -386,7 +386,7 @@ class TranslatorTask(Base):
                 for sub_index, sub_line in enumerate(lines):
                     # 仅当 **只有一个** 尾随空格时才去除
                     sub_line = sub_line[:-1] if re.match(r'.*[^ ] $', sub_line) else sub_line
-                    numbered_text += f""""{index + 1}.{total_lines - sub_index}.,{sub_line}",\n"""
+                    numbered_text += f'"{index + 1}.{total_lines - sub_index}.,{sub_line}",\n'
                 numbered_text = numbered_text.rstrip('\n')
                 numbered_text = numbered_text.rstrip(',')
                 numbered_text += f"\n]"  # 用json.dumps会影响到原文的转义字符
@@ -481,7 +481,7 @@ class TranslatorTask(Base):
                 for sub_index, sub_line in enumerate(lines):
                     # 仅当 **只有一个** 尾随空格时才去除
                     sub_line = sub_line[:-1] if re.match(r'.*[^ ] $', sub_line) else sub_line
-                    numbered_text += f""""{index + 1}.{total_lines - sub_index}.,{sub_line}",\n"""
+                    numbered_text += f'"{index + 1}.{total_lines - sub_index}.,{sub_line}",\n'
                 numbered_text = numbered_text.rstrip('\n')
                 numbered_text = numbered_text.rstrip(',')
                 numbered_text += f"\n]"  # 用json.dumps会影响到原文的转义字符


### PR DESCRIPTION
这ds-v3真是提供用例的好帮手啊（
又帮我补充了两个多行文本的例外

```
"1.1.,xxx
",    // 补充情况1，正文后多了个换行符 再跟的 ",

"1.1.,xxx"
,    // 补充情况2，正文后引号正常，但是引号后多了个换行符 再跟的 ,
```

顺便也尝试在组装文本前去掉正文中可能存在的重复序号