### PR TITLE
fix: 换行符检测未检查原文中的转义换行符

### DIFF
--- a/ModuleFolders/ResponseChecker/ResponseChecker.py
+++ b/ModuleFolders/ResponseChecker/ResponseChecker.py
@@ -204,6 +204,8 @@ class ResponseChecker():
 
             # 在处理过的文本上计算文本内的换行符数量
             source_newlines = trimmed_source_text.count('\n')
+            # 检查原文中的转义换行符
+            source_newlines += trimmed_source_text.count('\\n')
             translated_newlines = trimmed_translated_text.count('\n')
 
             # 检查换行符数是否匹配，要放在外面进行比较，因为source_text可能没有换行符，而译文就有

--- a/PluginScripts/TranslationCheckPlugin/TranslationCheckPlugin.py
+++ b/PluginScripts/TranslationCheckPlugin/TranslationCheckPlugin.py
@@ -451,6 +451,8 @@ class TranslationCheckPlugin(PluginBase):
 
         # 在处理过的文本上计算文本内的换行符数量
         source_newlines = trimmed_source_text.count('\n')
+        # 检查原文中的转义换行符
+        source_newlines += trimmed_source_text.count('\\n')
         translated_newlines = trimmed_translated_text.count('\n')
 
         if source_newlines != translated_newlines:


### PR DESCRIPTION
https://github.com/NEKOparapa/AiNiee/issues/601

值得注意的是，此pr并没有检查译文中的转义换行符，Paratranz平台在导入时会根据游戏类型自动转换，但不清楚其他载体的情况，或许严格一些比较好？

![image](https://github.com/user-attachments/assets/26064d72-61f7-4376-a8b7-942805e48ca8)
