### PR TITLE
修復BabelDOC最高版本

### DIFF
--- a/requirements_no_deps.txt
+++ b/requirements_no_deps.txt
@@ -1,3 +1,3 @@
 # 无依赖安装 pip install --no-deps
 mediapipe==0.10.14
-BabelDOC
+BabelDOC<=0.3.72


### PR DESCRIPTION
Fixes #658 

BabelDOC新版更改api需要限制最高版本
我不知道正確的打包方法，但已經用手動安裝(uv)的情況下測試過了