### PR TITLE
fix: 修复XML标签正则对非ASCII字符的支持问题 (#751)

### DIFF
--- a/ModuleFolders/FileReader/ReaderUtil.py
+++ b/ModuleFolders/FileReader/ReaderUtil.py
@@ -466,7 +466,8 @@ def clean_text(source_text):
     # 提取、拼接tag属性值
     cleaned_text = replace_tags_with_values(cleaned_text)
     # 提取xml标签带冒号格式的具体内容
-    cleaned_text = re.sub(r'<[a-zA-Z_]+:(.*?)>', tag_handler, cleaned_text)
+    # 20250825fix: 修复XML标签名正则不支持非ASCII字符的问题
+    cleaned_text = re.sub(r'<[^:]+:(.*?)>', tag_handler, cleaned_text)
     # 去除html标签
     cleaned_text = remove_html_tags(cleaned_text).strip()
     # 去除文本前后的转义换行符(\n)


### PR DESCRIPTION
## 修复XML标签正则对非ASCII字符的支持问题

Fixes #751

### 问题描述
当前正则 `<[a-zA-Z_]+:(.*?)>` 只能匹配ASCII字母的XML标签名，导致类似 `<SG説明:content>` 的标签被当作HTML标签处理，内容被BeautifulSoup完全移除。

### 解决方案
将正则表达式更新为 `<[^:]+:(.*?)>`，匹配冒号前的任意字符，支持标签名中的中日文字符。

### 影响
- 修复了处理包含非ASCII字符标签名时的内容丢失问题
- 保持对ASCII标签名的现有功能
- 无API破坏性变更