### PR TITLE
Fix continue-task cache reload timing (#762)

### DIFF
--- a/ModuleFolders/Cache/CacheManager.py
+++ b/ModuleFolders/Cache/CacheManager.py
@@ -100,8 +100,17 @@ class CacheManager(Base):
                     json_data = {"total_line": total_line, "line": line, "project_name": project_name}
 
                     json_path = os.path.join(cache_dir, "ProjectStatistics.json")
-                    with open(json_path, "w", encoding="utf-8") as writer:
-                        json.dump(json_data, writer, ensure_ascii=False, indent=4)
+                    json_tmp_path = json_path + f".{os.getpid()}.tmp"
+                    try:
+                        with open(json_tmp_path, "w", encoding="utf-8") as writer:
+                            json.dump(json_data, writer, ensure_ascii=False, indent=4)
+                        os.replace(json_tmp_path, json_path)
+                    finally:
+                        if os.path.exists(json_tmp_path):
+                            try:
+                                os.remove(json_tmp_path)
+                            except OSError:
+                                pass
                 else:
                     # 如果stats_data不存在，则调用 Base 类中的 warning 方法打印警告并跳过
                     self.warning(f"CacheManager: self.project.stats_data is None. Skipping ProjectStatistics.json update.")


### PR DESCRIPTION
- **Base 分支**：`main`
- **Compare 分支**：`fix/issue762`
- **问题根因**：
  - 在 7.0.5 之前，`CacheManager.save_to_file` 直接覆盖 `ProjectStatistics.json`，如果写盘过程中被终止，磁盘上会留下空文件或半写文件。
  - UI 在继续任务时立刻 `json.load()` 该文件，遇到空内容或格式错误会抛异常并终止线程，最终表现为 Win10 用户继续任务卡死（Issue #762）。
- **解决方案**：
  - 写盘阶段改为“临时文件 + `os.replace()`”，保证任何时候磁盘上只有完整文件。
  - `EditViewPage.task_continue_check_target` 在检测继续状态时：
    - 增加文件存在与大小检查；
    - 最多三次重试读取，采用指数退避；
    - 读取失败时输出告警并优雅退出，而不是抛异常。
