### PR TITLE
chore: 更新 .gitignore 以忽略临时输出目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ PluginScripts/IOPlugins/*
 .idea/
 # 构建文件
 *.spec
+.DS_Store
+bilingual_auto/
+downloads/


### PR DESCRIPTION
### 背景 (Context)
我是之前反馈 EPUB 原文丢失问题的 @XiChuan9。
(I am the one who reported the EPUB source text missing issue. )
“[[Bug]: EPUB bilingual export loses source text due to incomplete HTML parsing](https://github.com/NEKOparapa/AiNiee/issues/848)
bug
Something isn't working
Status: Open.
#848”

### 变更说明 (Changes)
我原计划提交 `EpubWriter.py` 的修复代码，但拉取最新代码时发现您已经高效地修复并合并了（代码逻辑与我的一致），非常感谢！
(I originally planned to submit the fix for `EpubWriter.py`, but I noticed you've already fixed and merged it efficiently. Thanks for the quick fix!)

因此，我同步代码后，提交了这个关于 `.gitignore` 的小优化：
(So, after syncing the code, I'm submitting this small optimization for `.gitignore`:)

* **忽略 `bilingual_auto/`**: 防止翻译输出结果误上传。
    (Ignore translation output directory.)
* **忽略 `downloads/`**: 防止模型下载缓存误上传。
    (Ignore download cache directory.)
* **忽略 `.DS_Store`**: 忽略 macOS 系统文件。
    (Ignore macOS system files.)

希望能对项目维护有所帮助。
(Hope this helps maintain the project clean.)