### PR TITLE
🐛 fix(`ModuleFolders`): 修复 `os.environ` 补丁方法签名并更新 tiktoken 编码文件大小

### DIFF
--- a/ModuleFolders/BabeldocPatch.py
+++ b/ModuleFolders/BabeldocPatch.py
@@ -40,7 +40,7 @@ def apply_patch(custom_cache_dir: str) -> None:
     # 保存原始的 __setitem__ 方法
     _ORIGINAL_SETITEM = os.environ.__setitem__
 
-    def protected_setitem(key: str, value: str) -> None:
+    def protected_setitem(self, key: str, value: str) -> None:
         """
         替换 os.environ 的 __setitem__ 方法
 
@@ -75,7 +75,7 @@ def apply_patch(custom_cache_dir: str) -> None:
                 del frame
 
         # 其他情况，使用原始方法正常设置
-        _ORIGINAL_SETITEM(key, value)
+        _ORIGINAL_SETITEM(self, key, value)
 
     # 替换 os.environ 的 __setitem__ 方法
     # 使用 type() 获取 os.environ 的类型，然后设置其方法

--- a/ModuleFolders/TiktokenLoader.py
+++ b/ModuleFolders/TiktokenLoader.py
@@ -94,11 +94,11 @@ def initialize_tiktoken():
         required_encodings = {
             "o200k_base": {
                 "url": "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
-                "size": 3613922,
+                "size": 3813920,
             },
             "cl100k_base": {
                 "url": "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
-                "size": 1681126,
+                "size": 1781382,
             }
         }
 


### PR DESCRIPTION
修复 `os.environ` 补丁方法签名并更新 tiktoken 编码文件大小