### PR TITLE
fix(ModelBrowserDialog): 修复类型为 Google 的自定义接口无法获取模型列表的问题

### DIFF
--- a/UserInterface/Platform/ModelBrowserDialog.py
+++ b/UserInterface/Platform/ModelBrowserDialog.py
@@ -266,8 +266,9 @@ class ModelBrowserDialog(MessageBoxBase, Base):
 
     # 拉取模型（异步）
     def _fetch_models(self) -> None:
-        # 判断平台类型
-        if self.platform_key == "google":
+        # 判断平台类型：google 官方接口或自定义接口使用 Google 格式时，使用原生 Google API
+        api_format = self.platform_config.get("api_format", "")
+        if self.platform_key == "google" or api_format == "Google":
             self._thread = QThread(self)
             self._worker = _GoogleModelFetchWorker(self.platform_config)
             self._worker.moveToThread(self._thread)


### PR DESCRIPTION
## 关联 Issue

Fix #898 

## 问题描述

当用户创建"自定义接口"并将 `api_format` 设置为 [Google](cci:2://file:///D:/Code/AiNiee/ModuleFolders/Infrastructure/LLMRequester/GoogleRequester.py:8:0-107:88) 格式时，点击"获取模型"按钮无法正确获取模型列表。

## 原因分析

在 `ModelBrowserDialog._fetch_models()` 方法中，原有逻辑只检查 `platform_key == "google"` 来判断是否使用 Google 原生 API：

```python
# 修改前
if self.platform_key == "google":
```

自定义接口（platform_key == "custom"）即使设置了 api_format == "Google"，也会错误地走 OpenAI 兼容接口路径。

## 解决方案

增加对 api_format 的判断：

```python
# 修改后
api_format = self.platform_config.get("api_format", "")
if self.platform_key == "google" or api_format == "Google":
```

## 测试验证

 - [x] 官方 Google 接口正常获取模型列表
 - [x] 自定义接口（api_format=Google）正常获取模型列表
 - [x] 自定义接口（api_format=OpenAI）仍使用 OpenAI 兼容接口