### PR TITLE
 OpenAI 请求器新增 SSE 降级解析机制，兼容中转站非标准响应

### DIFF
--- a/ModuleFolders/Infrastructure/LLMRequester/OpenaiRequester.py
+++ b/ModuleFolders/Infrastructure/LLMRequester/OpenaiRequester.py
@@ -1,11 +1,91 @@
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Infrastructure.LLMRequester.LLMClientFactory import LLMClientFactory
 
+import json
+from openai.types.chat import ChatCompletion
+
 
 # 接口请求器
 class OpenaiRequester(Base):
     def __init__(self) -> None:
         pass
+
+    # 手动解析SSE流式响应，合并为完整的ChatCompletion结果
+    def _parse_sse_response(self, raw_text: str) -> tuple[str, str, int, int]:
+        """
+        解析SSE格式的流式响应，将多个chunk合并为完整结果。
+        返回: (response_think, response_content, prompt_tokens, completion_tokens)
+        """
+        response_content = ""
+        response_think = ""
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        for line in raw_text.splitlines():
+            # 跳过空行和非data行（如 event:、id:、retry:）
+            if not line.startswith("data:"):
+                continue
+
+            data_str = line[5:].strip()
+
+            if data_str == "[DONE]":
+                break
+
+            try:
+                chunk = json.loads(data_str)
+            except json.JSONDecodeError:
+                continue
+
+            # 提取 delta 中的内容
+            choices = chunk.get("choices")
+            if choices:
+                delta = choices[0].get("delta", {})
+                if delta.get("content"):
+                    response_content += delta["content"]
+                if delta.get("reasoning_content"):
+                    response_think += delta["reasoning_content"]
+
+            # 提取 usage 信息（通常在最后一个 chunk）
+            usage = chunk.get("usage")
+            if usage:
+                prompt_tokens = usage.get("prompt_tokens", 0)
+                completion_tokens = usage.get("completion_tokens", 0)
+
+        return response_think, response_content, prompt_tokens, completion_tokens
+
+    # 从响应中提取内容和token消耗
+    def _extract_from_completion(self, response: ChatCompletion) -> tuple[str, str, int, int]:
+        """
+        从ChatCompletion对象中提取内容。
+        返回: (response_think, response_content, prompt_tokens, completion_tokens)
+        """
+        message = response.choices[0].message
+
+        # 自适应提取推理过程
+        if "</think>" in message.content:
+            splited = message.content.split("</think>")
+            response_think = splited[0].removeprefix("<think>").replace("\n\n", "\n")
+            response_content = splited[-1]
+        else:
+            try:
+                response_think = message.reasoning_content
+                if not response_think:
+                    response_think = ""
+            except Exception:
+                response_think = ""
+            response_content = message.content
+
+        # 获取token消耗
+        try:
+            prompt_tokens = int(response.usage.prompt_tokens)
+        except Exception:
+            prompt_tokens = 0
+        try:
+            completion_tokens = int(response.usage.completion_tokens)
+        except Exception:
+            completion_tokens = 0
+
+        return response_think, response_content, prompt_tokens, completion_tokens
 
     # 发起请求
     def request_openai(self, messages, system_prompt, platform_config) -> tuple[bool, str, str, int, int]:
@@ -17,7 +97,7 @@ class OpenaiRequester(Base):
             top_p = platform_config.get("top_p", 1.0)
             presence_penalty = platform_config.get("presence_penalty", 0)
             frequency_penalty = platform_config.get("frequency_penalty", 0)
-            extra_body = platform_config.get("extra_body", "{}")
+            extra_body = platform_config.get("extra_body", {})
             think_switch = platform_config.get("think_switch")
             think_depth = platform_config.get("think_depth")
 
@@ -39,7 +119,6 @@ class OpenaiRequester(Base):
                 if messages and isinstance(messages[-1], dict) and messages[-1].get('role') != 'user':
                     messages = messages[:-1]  # 移除最后一个元素
 
-
             # 参数基础配置
             base_params = {
                 "extra_body": extra_body,
@@ -51,68 +130,55 @@ class OpenaiRequester(Base):
 
             # 按需添加参数
             if temperature != 1:
-                base_params.update({
-                    "temperature": temperature,
-                })
-
+                base_params["temperature"] = temperature
             if top_p != 1:
-                base_params.update({
-                    "top_p": top_p,
-                })
-
+                base_params["top_p"] = top_p
             if presence_penalty != 0:
-                base_params.update({
-                    "presence_penalty": presence_penalty,
-                })
-
+                base_params["presence_penalty"] = presence_penalty
             if frequency_penalty != 0:
-                base_params.update({
-                    "frequency_penalty": frequency_penalty
-                })
-
+                base_params["frequency_penalty"] = frequency_penalty
 
             # 开启思考开关时添加参数
             if think_switch:
-                base_params.update({
-                    "reasoning_effort": think_depth
-                })
+                base_params["reasoning_effort"] = think_depth
 
+            # 使用with_raw_response获取原始响应，以便处理中转站强制返回流式响应的情况
+            raw_response = client.chat.completions.with_raw_response.create(**base_params)
 
-            # 发起请求
-            response = client.chat.completions.create(**base_params)
+            # 尝试解析响应，部分中转站可能无视stream=False强制返回流式响应
+            try:
+                response = raw_response.parse()
+            except Exception as parse_error:
+                # parse报错（如text/json头但内容是SSE导致JSON解析失败），降级为SSE处理
+                if self.is_debug():
+                    self.debug(f"响应解析失败: {parse_error}，尝试作为SSE处理")
+                response = None
 
-
-            # 提取回复内容
-            message = response.choices[0].message
-
-            # 自适应提取推理过程
-            if "</think>" in message.content:
-                splited = message.content.split("</think>")
-                response_think = splited[0].removeprefix("<think>").replace("\n\n", "\n")
-                response_content = splited[-1]
+            # 根据响应类型选择处理方式
+            if isinstance(response, ChatCompletion):
+                # 标准非流式响应处理
+                response_think, response_content, prompt_tokens, completion_tokens = self._extract_from_completion(
+                    response)
             else:
-                try:
-                    response_think = message.reasoning_content
-                    if not response_think:
-                        response_think = ""
-                except Exception:
-                    response_think = ""
-                response_content = message.content
+                # 非标准响应，尝试作为SSE流式响应解析
+                if self.is_debug():
+                    self.debug(f"收到非标准响应，尝试作为SSE处理")
+
+                raw_text = raw_response.text
+                response_think, response_content, prompt_tokens, completion_tokens = self._parse_sse_response(raw_text)
+
+                # 自适应提取推理过程（针对某些模型将推理内容嵌入content的情况）
+                if response_content and "</think>" in response_content:
+                    splited = response_content.split("</think>")
+                    response_think = splited[0].removeprefix("<think>").replace("\n\n", "\n")
+                    response_content = splited[-1]
+
+                # SSE解析后仍无内容，视为失败
+                if not response_content:
+                    raise ValueError(f"无法解析响应内容，原始响应: {raw_text[:500]}")
 
         except Exception as e:
             self.error(f"请求任务错误 ... {e}", e if self.is_debug() else None)
             return True, None, None, None, None
-
-        # 获取指令消耗
-        try:
-            prompt_tokens = int(response.usage.prompt_tokens)
-        except Exception:
-            prompt_tokens = 0
-
-        # 获取回复消耗
-        try:
-            completion_tokens = int(response.usage.completion_tokens)
-        except Exception:
-            completion_tokens = 0
 
         return False, response_think, response_content, prompt_tokens, completion_tokens


### PR DESCRIPTION
部分 API 中转站在请求参数 `stream=False` 时仍强制返回流式响应，导致 OpenAI SDK 标准解析失败。

## 改动

**SSE 降级解析机制（OpenAI 请求器）**

- 使用 `with_raw_response` 获取原始响应，根据解析结果自动选择处理路径
- 标准 `ChatCompletion` 响应走原有逻辑
- `text/event-stream` 响应头（parse 返回 str）自动降级为 SSE 解析
- `text/json` 响应头但实际内容为 SSE（parse 抛异常）同样降级处理

**SSE 解析实现**

- 新增 `_parse_sse_response` 方法，逐行解析 SSE 数据并合并为完整结果
- 使用 `splitlines()` 兼容 `\n`、`\r\n`、`\r` 多种换行符格式

**其他修复**

- 修复 `extra_body` 默认值类型错误（`"{}"` → `{}`）

Related to #919 