### PR TITLE
fix: prevent stuck UI state when starting tasks without API binding

### DIFF
--- a/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
+++ b/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
@@ -188,18 +188,31 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
         continue_status = data.get("continue_status")
         current_mode = data.get("current_mode")
 
+        def run_task_target(target_func, *args) -> None:
+            try:
+                target_func(*args)
+            except Exception as e:
+                self.print("")
+                self.error(f"任务启动失败或执行异常 ... {e}", e if self.is_debug() else None)
+                self.print("")
+
+                Base.work_status = Base.STATUS.TASKSTOPPED
+                self._cancel_active_executor()
+                LLMClientFactory().close_all_clients()
+                self.emit(Base.EVENT.TASK_STOP_DONE, {})
+
         # 翻译任务
         if current_mode == TaskType.TRANSLATION:
             threading.Thread(
-                target = self.translation_start_target,
-                args = (continue_status,),
+                target = run_task_target,
+                args = (self.translation_start_target, continue_status,),
             ).start()
         
         # 润色任务
         elif current_mode == TaskType.POLISH:
             threading.Thread(
-                target = self.polish_start_target,
-                args = (continue_status,),
+                target = run_task_target,
+                args = (self.polish_start_target, continue_status,),
             ).start()
 
         else:
@@ -615,4 +628,3 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
             return
         except Exception as e:
             self.error(f"翻译任务错误 ... {e}", e if self.is_debug() else None)
-

--- a/UserInterface/EditView/EditViewPage.py
+++ b/UserInterface/EditView/EditViewPage.py
@@ -205,6 +205,8 @@ class BottomCommandBar(ConfigMixin, LogMixin, ToastMixin, Base, CardWidget):
     # 开始按钮
     def command_play(self) -> None:
         """开始新任务"""
+        if not self._has_valid_api_binding():
+            return
         if self.has_resumable_task:
             info_cont1 = self.tra("将重置尚未完成的任务") + "  ... ？"
             message_box = MessageBox("Warning", info_cont1, self.window())
@@ -272,6 +274,26 @@ class BottomCommandBar(ConfigMixin, LogMixin, ToastMixin, Base, CardWidget):
     def on_arrow_clicked(self):
         self.arrowClicked.emit()
 
+    def _has_valid_api_binding(self) -> bool:
+        config = self.load_config()
+        api_settings = config.get("api_settings", {})
+        platforms = config.get("platforms", {})
+
+        target_type = "translate" if self.current_mode == TaskType.TRANSLATION else "polish"
+        target_name = self.tra("翻译") if target_type == "translate" else self.tra("润色")
+        selected_tag = api_settings.get(target_type)
+
+        if not selected_tag:
+            content = self.tra("未设置") + target_name + self.tra("接口，请先到接口管理页面绑定接口。")
+            self.error_toast(self.tra("错误"), content)
+            return False
+
+        if selected_tag not in platforms:
+            content = self.tra("当前") + target_name + self.tra("接口配置不存在，请重新到接口管理页面选择。")
+            self.error_toast(self.tra("错误"), content)
+            return False
+
+        return True
 # 层级浏览器
 class NavigationCard(ConfigMixin, LogMixin, ToastMixin, Base, CardWidget):
     searchRequested = pyqtSignal(dict)  # 信号，发送搜索参数字典


### PR DESCRIPTION
## Summary

This PR fixes a UI/task-state issue when starting translation or polishing without a configured API binding.

## Problem

If no translation/polish API is configured and the user clicks "Start", the UI may enter a running/stopping state even though the task thread fails immediately. In that state, stop/back actions can become ineffective.

## Root Cause

There were two gaps:

1. The start action did not validate whether the required API binding existed before dispatching the task.
2. If the background task thread failed during startup, the task/UI state was not always restored.

## Changes

- Add a pre-check before starting translation/polishing to ensure the required API binding exists.
- Show a clear error toast when the binding is missing.
- Wrap task startup threads with exception handling so unexpected startup failures restore task state and UI controls.

## Reproduction

1. Launch the app with no translation API configured.
2. Import a file.
3. Click "Start Translation".
4. Before this fix, the UI could enter an invalid running/stopping state.

## After Fix

- The app immediately asks the user to configure the required API.
- The UI remains responsive.
- Back navigation works normally.
- Unexpected startup failures no longer leave the task state stuck.

## Verification

- Reproduced in the GUI with no translation API configured.
- Verified that clicking "Start Translation" now immediately shows an error.
- Verified that the page can still return normally.
- Verified the patched files pass Python syntax check.

中文补充：这个问题是在本地 GUI 实际点击流程中复现并验证修复的。
