### PR TITLE
fix: avoid file name too long errors for long PDF outputs

### DIFF
--- a/ModuleFolders/Domain/FileAccessor/BabeldocPdfAccessor.py
+++ b/ModuleFolders/Domain/FileAccessor/BabeldocPdfAccessor.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import shutil
 from concurrent.futures import Executor, Future
 from concurrent.futures.thread import _WorkItem
 from pathlib import Path
@@ -145,6 +147,7 @@ class BabeldocPdfAccessor:
         self.tmp_directory = tmp_directory
         self.output_config = output_config
         self._result_cache: dict[(Path, int), TranslateResult] = {}
+        self._input_alias_cache: dict[Path, Path] = {}
         self._init_babeldoc_args()
 
     def _init_babeldoc_args(self):
@@ -167,8 +170,9 @@ class BabeldocPdfAccessor:
 
     def read_content(self, source_file_path: Path):
         visitor = PdfSourceVisitor()
+        prepared_source_file_path = self._prepare_babeldoc_input_file(source_file_path)
         babeldoc_translation_config = self._create_babeldoc_translation_config(
-            self.babeldoc_args, str(source_file_path), visitor
+            self.babeldoc_args, str(prepared_source_file_path), visitor
         )
 
         old_il_translate = il_translator.ILTranslator.translate
@@ -211,8 +215,9 @@ class BabeldocPdfAccessor:
             return result
 
         translator = TranslatedItemsTranslator(items)
+        prepared_source_file_path = self._prepare_babeldoc_input_file(source_file_path)
         babeldoc_translation_config = self._create_babeldoc_translation_config(
-            self.babeldoc_args, str(source_file_path), translator
+            self.babeldoc_args, str(prepared_source_file_path), translator
         )
         try:
             progress_monitor.TranslationStage = TranslationStage
@@ -230,6 +235,42 @@ class BabeldocPdfAccessor:
         self._result_cache.clear()
         self._result_cache[cache_id] = result
         return result
+
+    def _prepare_babeldoc_input_file(self, source_file_path: Path) -> Path:
+        source_file_path = source_file_path.resolve()
+        cached_path = self._input_alias_cache.get(source_file_path)
+        if cached_path and cached_path.exists():
+            return cached_path
+
+        alias_directory = self.tmp_directory / "input_alias"
+        alias_directory.mkdir(parents=True, exist_ok=True)
+
+        safe_stem = self._build_short_pdf_stem(source_file_path)
+        alias_path = alias_directory / f"{safe_stem}{source_file_path.suffix.lower() or '.pdf'}"
+
+        if alias_path.exists() or alias_path.is_symlink():
+            alias_path.unlink()
+
+        try:
+            alias_path.symlink_to(source_file_path)
+        except OSError:
+            shutil.copy2(source_file_path, alias_path)
+
+        self._input_alias_cache[source_file_path] = alias_path
+        return alias_path
+
+    @staticmethod
+    def _build_short_pdf_stem(source_file_path: Path) -> str:
+        sanitized_stem = ''.join(
+            ch if ch.isalnum() or ch in ('-', '_') else '_'
+            for ch in source_file_path.stem
+        ).strip('_')
+        if not sanitized_stem:
+            sanitized_stem = "pdf"
+
+        shortened_prefix = sanitized_stem[:32].rstrip('_')
+        digest = hashlib.sha1(str(source_file_path).encode("utf-8")).hexdigest()[:12]
+        return f"{shortened_prefix}_{digest}" if shortened_prefix else f"pdf_{digest}"
 
     @classmethod
     def _create_babeldoc_translation_config(cls, args, file, translator):

--- a/ModuleFolders/Domain/FileOutputer/DirectoryWriter.py
+++ b/ModuleFolders/Domain/FileOutputer/DirectoryWriter.py
@@ -1,3 +1,4 @@
+import hashlib
 from pathlib import Path
 from typing import Callable
 
@@ -14,6 +15,8 @@ from ModuleFolders.Domain.FileOutputer.BaseWriter import (
 
 
 class DirectoryWriter:
+    MAX_FILENAME_BYTES = 240
+
     def __init__(self, create_writer: Callable[[], BaseTranslationWriter]):
         self.create_writer = create_writer
 
@@ -60,8 +63,35 @@ class DirectoryWriter:
 
     @classmethod
     def with_file_suffix(self, file_path: str, name_suffix: str) -> Path:
-        parts = file_path.rsplit(".", 1)
-        if len(parts) == 2:
-            return f"{parts[0]}{name_suffix}.{parts[1]}"
-        else:
-            return f"{parts[0]}{name_suffix}"
+        path = Path(file_path)
+        extension = path.suffix
+        stem = path.stem if extension else path.name
+        suffix_with_extension = f"{name_suffix}{extension}"
+        output_name = self._build_safe_output_name(stem, suffix_with_extension)
+        return path.with_name(output_name)
+
+    @classmethod
+    def _build_safe_output_name(self, stem: str, suffix_with_extension: str) -> str:
+        candidate = f"{stem}{suffix_with_extension}"
+        if len(candidate.encode("utf-8")) <= self.MAX_FILENAME_BYTES:
+            return candidate
+
+        digest = hashlib.sha1(stem.encode("utf-8")).hexdigest()[:10]
+        reserved_suffix = f"_{digest}{suffix_with_extension}"
+        available_bytes = max(16, self.MAX_FILENAME_BYTES - len(reserved_suffix.encode("utf-8")))
+        shortened_stem = self._truncate_utf8_bytes(stem, available_bytes).rstrip(" ._")
+        if not shortened_stem:
+            shortened_stem = "file"
+        return f"{shortened_stem}_{digest}{suffix_with_extension}"
+
+    @staticmethod
+    def _truncate_utf8_bytes(text: str, max_bytes: int) -> str:
+        current_bytes = 0
+        result_chars: list[str] = []
+        for ch in text:
+            ch_bytes = len(ch.encode("utf-8"))
+            if current_bytes + ch_bytes > max_bytes:
+                break
+            result_chars.append(ch)
+            current_bytes += ch_bytes
+        return "".join(result_chars)


### PR DESCRIPTION
## Summary

This PR fixes `File name too long` failures when translating PDFs with very long source filenames.

## Problem

On macOS, PDF translation could finish successfully but fail during the final save step when the source PDF filename was very long.

The failure happened in two places:

1. `babeldoc` used `Path(input_file).stem` to generate intermediate mono/dual PDF filenames, which could exceed the filesystem filename limit.
2. AiNiee then generated the final output filename from the original long source filename again, which could also exceed the limit.

This resulted in errors such as:

- `OSError: [Errno 63] File name too long`
- PDF output not being written even though translation/typesetting had already completed

## Changes

- Add a short deterministic alias for the source PDF before passing it to `babeldoc`, so intermediate filenames stay within safe limits.
- Add a filesystem-safe filename guard in the shared output writer, so excessively long generated output filenames are truncated only when necessary.
- Preserve readable prefixes, original suffixes/extensions, and append a short hash to avoid collisions.

## Behavior

- Normal-length filenames are unchanged.
- Only filenames that would exceed a safe byte-length limit are shortened.
- This keeps the fix minimal while avoiding save failures on macOS.

## Reproduction

1. Use a PDF with a very long filename.
2. Translate it with PDF output enabled.
3. Before this fix, translation could complete but final PDF save would fail with `File name too long`.

## Verification

- Reproduced locally on macOS with a long English PDF filename under a non-trivial parent path.
- Verified that the same PDF now successfully generates:
  - translated PDF
  - bilingual PDF
- Verified Python syntax checks pass.

If you prefer a different shortening policy for overlong filenames, I'm happy to adjust it.
