### PR TITLE
修复pdf复制乱码

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,7 @@ sounddevice>=0.4.4
 # onnx 新版本打包后不能运行，这里使用 onnx==1.16.1 onnxruntime==1.20.1
 # rapidocr-onnxruntime 依赖了 opencv-python，所以去除了 opencv-python-headless
 # 不使用 babeldoc.document_il.midend.detect_scanned_file.DetectScannedFile 所以去除 scikit-image>=0.25.2
-bitarray>=3.0.0,<4.0
-bitstring==4.3.1
+bitstring>=4.3.0
 configargparse>=1.7
 httpx[socks]>=0.27.0
 huggingface-hub>=0.27.0
@@ -54,10 +53,11 @@ onnx==1.16.1
 onnxruntime==1.20.1
 openai>=1.59.3
 orjson>=3.10.14
-pdfminer-six==20250416
+charset-normalizer>=2.0.0
+cryptography>=36.0.0
 peewee>=3.17.8
 psutil>=7.0.0
-pymupdf>=1.25.1
+pymupdf==1.26.7
 rich>=13.9.4
 toml>=0.10.2
 tqdm>=4.67.1
@@ -67,8 +67,9 @@ pydantic>=2.10.6
 tenacity>=9.0.0
 freetype-py>=2.5.1
 tiktoken>=0.9.0
-python-levenshtein>=0.27.1
+levenshtein>=0.27.1
 rapidocr-onnxruntime>=1.4.4
 pyzstd
 rtree
+uharfbuzz>=0.50.2
 scikit-learn>=1.7.1


### PR DESCRIPTION
#992 
1. 回退pymupdf版本
2. 更新babeldoc其他依赖版本