### PR TITLE
术语表正则优化

### DIFF
--- a/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
+++ b/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
@@ -17,6 +17,7 @@ class GlossaryHelper:
 
     @staticmethod
     def _parse_source_text(source_text: str):
+        # 使用 regex 解析树区分纯字面量和真实正则
         return regex._regex_core._parse_pattern(
             regex._regex_core.Source(source_text),
             regex._regex_core.Info(),
@@ -24,6 +25,7 @@ class GlossaryHelper:
 
     @classmethod
     def _extract_literal_text(cls, node) -> str | None:
+        # 只有完整还原为连续字符时，才视为普通术语。
         if isinstance(node, regex._regex_core.Sequence):
             literal_parts = []
             for item in node.items:
@@ -99,6 +101,7 @@ class GlossaryHelper:
 
     @classmethod
     def normalize_row(cls, row: dict) -> dict:
+        # 持久化校验结果，UI 与任务流程复用同一份有效性判断。
         normalized_row = dict(row) if isinstance(row, dict) else {}
         normalized_row["src"] = cls._normalize_text(normalized_row.get("src", ""))
         normalized_row["dst"] = cls._normalize_text(normalized_row.get("dst", ""))
@@ -134,6 +137,7 @@ class GlossaryHelper:
             return None
 
         try:
+            # 正则保持 regex 默认大小写规则；普通术语继续忽略大小写。
             if cls.is_regex_pattern(source_text):
                 return cls._compile_source_text(source_text)
 
@@ -178,6 +182,7 @@ class GlossaryHelper:
                 seen_texts.add(match_text)
 
             for match_text in found_texts:
+                # 提示词使用实际命中的文本，保留原文大小写。
                 dedupe_key = (match_text, row.get("dst", ""))
                 if dedupe_key in seen_keys:
                     continue

--- a/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
+++ b/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
@@ -1,0 +1,190 @@
+import regex
+import regex._regex_core
+
+
+class GlossaryHelper:
+    VALID_KEY = "is_valid"
+
+    @staticmethod
+    def _normalize_text(value) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @staticmethod
+    def _compile_source_text(source_text: str):
+        return regex.compile(source_text)
+
+    @staticmethod
+    def _parse_source_text(source_text: str):
+        return regex._regex_core._parse_pattern(
+            regex._regex_core.Source(source_text),
+            regex._regex_core.Info(),
+        )
+
+    @classmethod
+    def _extract_literal_text(cls, node) -> str | None:
+        if isinstance(node, regex._regex_core.Sequence):
+            literal_parts = []
+            for item in node.items:
+                literal_text = cls._extract_literal_text(item)
+                if literal_text is None:
+                    return None
+
+                literal_parts.append(literal_text)
+
+            return "".join(literal_parts)
+
+        if isinstance(node, regex._regex_core.Character):
+            if not node.positive or node.case_flags or node.zerowidth:
+                return None
+
+            try:
+                return chr(node.value)
+            except (TypeError, ValueError):
+                return None
+
+        return None
+
+    @classmethod
+    def _get_literal_text(cls, source_text: str) -> str | None:
+        source_text = cls._normalize_text(source_text)
+        if not source_text:
+            return ""
+
+        try:
+            parsed_pattern = cls._parse_source_text(source_text)
+        except Exception:
+            return None
+
+        return cls._extract_literal_text(parsed_pattern)
+
+    @classmethod
+    def is_regex_pattern(cls, source_text: str) -> bool:
+        source_text = cls._normalize_text(source_text)
+        if not source_text:
+            return False
+
+        if not cls.validate_source_text(source_text):
+            return False
+
+        literal_text = cls._get_literal_text(source_text)
+        if literal_text is None:
+            return True
+
+        return literal_text != source_text
+
+    @classmethod
+    def validate_source_text(cls, source_text: str) -> bool:
+        source_text = cls._normalize_text(source_text)
+        if not source_text:
+            return True
+
+        try:
+            cls._compile_source_text(source_text)
+            return True
+        except regex.error:
+            return False
+
+    @classmethod
+    def is_row_valid(cls, row: dict) -> bool:
+        if not isinstance(row, dict):
+            return False
+
+        stored = row.get(cls.VALID_KEY)
+        if isinstance(stored, bool):
+            return stored
+
+        return cls.validate_source_text(row.get("src", ""))
+
+    @classmethod
+    def normalize_row(cls, row: dict) -> dict:
+        normalized_row = dict(row) if isinstance(row, dict) else {}
+        normalized_row["src"] = cls._normalize_text(normalized_row.get("src", ""))
+        normalized_row["dst"] = cls._normalize_text(normalized_row.get("dst", ""))
+        normalized_row["info"] = cls._normalize_text(normalized_row.get("info", ""))
+        normalized_row[cls.VALID_KEY] = cls.validate_source_text(normalized_row.get("src", ""))
+        return normalized_row
+
+    @classmethod
+    def normalize_rows(cls, rows: list[dict] | None) -> list[dict]:
+        normalized_rows = []
+
+        if not isinstance(rows, list):
+            return normalized_rows
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+
+            normalized_rows.append(cls.normalize_row(row))
+
+        return normalized_rows
+
+    @classmethod
+    def build_search_pattern(cls, source_text: str, is_valid: bool | None = None):
+        source_text = cls._normalize_text(source_text)
+        if not source_text:
+            return None
+
+        if is_valid is None:
+            is_valid = cls.validate_source_text(source_text)
+
+        if not is_valid:
+            return None
+
+        try:
+            if cls.is_regex_pattern(source_text):
+                return cls._compile_source_text(source_text)
+
+            return regex.compile(regex.escape(source_text), regex.IGNORECASE)
+        except regex.error:
+            return None
+
+    @classmethod
+    def source_matches_text(cls, source_text: str, full_text: str, is_valid: bool | None = None) -> bool:
+        pattern = cls.build_search_pattern(source_text, is_valid)
+        if pattern is None:
+            return False
+
+        return bool(pattern.search(full_text or ""))
+
+    @classmethod
+    def collect_matched_rows(cls, rows: list[dict] | None, input_dict: dict | None) -> list[dict]:
+        full_text = "\n".join(input_dict.values()) if isinstance(input_dict, dict) else ""
+        if not full_text:
+            return []
+
+        matched_rows = []
+        seen_keys = set()
+
+        for row in cls.normalize_rows(rows):
+            src = row.get("src", "")
+            if not src or not row.get(cls.VALID_KEY, True):
+                continue
+
+            pattern = cls.build_search_pattern(src, row.get(cls.VALID_KEY))
+            if pattern is None:
+                continue
+
+            found_texts = []
+            seen_texts = set()
+            for match in pattern.finditer(full_text):
+                match_text = match.group(0)
+                if not match_text or match_text in seen_texts:
+                    continue
+
+                found_texts.append(match_text)
+                seen_texts.add(match_text)
+
+            for match_text in found_texts:
+                dedupe_key = (match_text, row.get("dst", ""))
+                if dedupe_key in seen_keys:
+                    continue
+
+                new_row = row.copy()
+                new_row["src"] = match_text
+                matched_rows.append(new_row)
+                seen_keys.add(dedupe_key)
+
+        return matched_rows

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -724,11 +724,8 @@ class PromptBuilder(Base):
         #空格和圆点发送时显示
         DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
         for key_a, value_a in dictionary.items():
-            keywords = [key_a]
-            if "[Separator]" in key_a:
-                keywords = key_a.split("[Separator]")
-            elif " " in key_a or re.search(f"[{DOT_SEPARATORS}]", key_a):
-                keywords = re.split(f"[ {DOT_SEPARATORS}]+", key_a)
+            processed_key = key_a.replace("[Separator]", " ")
+            keywords = re.split(f"[ {DOT_SEPARATORS}]+", processed_key)
 
             keywords = [keyword.strip() for keyword in keywords if keyword.strip()]
 

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -2,6 +2,7 @@ import re
 from types import SimpleNamespace
 
 from ModuleFolders.Base.Base import Base
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Service.TaskExecutor import TranslatorUtil
 from ModuleFolders.Infrastructure.TaskConfig.TaskConfig import TaskConfig
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderEnum import PromptBuilderEnum
@@ -437,45 +438,10 @@ class PromptBuilder(Base):
 
     # 构造术语表
     def build_glossary_prompt(config: TaskConfig, input_dict: dict) -> str:
-        # 将输入字典中的所有值合并为一个字符串，方便正则全局匹配
-        full_text = "\n".join(input_dict.values())
-
-        # 筛选并处理匹配的条目
-        result = []
-        seen_keys = set() # 用于去重 (匹配到的实际原文, 译文)
-
-        for v in config.prompt_dictionary_data:
-            src = v.get("src", "")
-            if not src:
-                continue
-
-            try:
-                # 编译正则表达式，忽略大小写以保持与原逻辑一致的宽松匹配
-                pattern = re.compile(src, re.IGNORECASE)
-
-                # 查找所有匹配项 (set去重，处理同一词在文中多次出现的情况)
-                found_texts = set(m.group() for m in pattern.finditer(full_text))
-
-                # 如果正则匹配到了内容 (例如正则 (A|B) 匹配到了 A 和 B，这里会循环两次)
-                for match_text in found_texts:
-                    if not match_text: continue
-
-                    # 使用 (实际匹配文本, 译文) 作为唯一键进行去重
-                    key = (match_text, v.get("dst"))
-                    if key not in seen_keys:
-                        # 复制元数据，并将 src 替换为实际匹配到的原文文本
-                        new_entry = v.copy()
-                        new_entry["src"] = match_text
-                        result.append(new_entry)
-                        seen_keys.add(key)
-
-            except re.error:
-                # 如果正则编译失败（非合法正则），回退到普通字符串包含判断
-                if src.lower() in full_text.lower():
-                    key = (src, v.get("dst"))
-                    if key not in seen_keys:
-                        result.append(v)
-                        seen_keys.add(key)
+        result = GlossaryHelper.collect_matched_rows(
+            getattr(config, "prompt_dictionary_data", []),
+            input_dict,
+        )
 
         # 数据校验
         if len(result) == 0:

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -721,22 +721,42 @@ class PromptBuilder(Base):
             dictionary[item.get("original_name", "")] = item
 
         temp_dict = {}
+        full_text = "\n".join(input_dict.values())
         #空格和圆点发送时显示
         DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
         for key_a, value_a in dictionary.items():
-            processed_key = key_a.replace("[Separator]", " ")
-            keywords = re.split(f"[ {DOT_SEPARATORS}]+", processed_key)
+            keywords = [key_a]
+            if "[Separator]" in key_a:
+                keywords = key_a.split("[Separator]")
+            elif " " in key_a or re.search(f"[{DOT_SEPARATORS}]", key_a):
+                keywords = re.split(f"[ {DOT_SEPARATORS}]+", key_a)
 
             keywords = [keyword.strip() for keyword in keywords if keyword.strip()]
 
-            is_match = False
-            for value_b in input_dict.values():
-                for keyword in keywords:
-                    if keyword and keyword in value_b:
-                        temp_dict[key_a] = value_a
-                        is_match = True
-                        break
-                if is_match:
+            for keyword in keywords:
+                if not keyword:
+                    continue
+
+                # 无视大小写查找匹配部分
+                match = re.search(re.escape(keyword), full_text, re.IGNORECASE)
+                if match:
+                    actual_text = match.group()
+
+                    # 复制配置，避免污染全局数据
+                    new_value = value_a.copy()
+                    orig_name = new_value.get("original_name", "")
+
+                    # 将原名中的对应部分替换为文本里实际的大小写
+                    new_value["original_name"] = re.sub(
+                        re.escape(keyword),
+                        lambda _: actual_text,
+                        orig_name,
+                        count=1,
+                        flags=re.IGNORECASE
+                    )
+
+                    # 存入临时字典，基于 key_a 去重，防止该角色的多个关键词匹配导致重复添加
+                    temp_dict[key_a] = new_value
                     break
 
         if temp_dict == {}:

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -714,6 +714,80 @@ class PromptBuilder(Base):
             "Original Text|Category|Remarks",
         )
 
+    # 圆点系列，匹配时与空格按同类处理
+    CHARACTERIZATION_DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
+
+    # 原名拆分为可匹配的关键词
+    def _split_characterization_name(original_name: str) -> list[str]:
+        if not original_name:
+            return []
+
+        if "[Separator]" in original_name:
+            parts = original_name.split("[Separator]")
+        elif " " in original_name or re.search(f"[{PromptBuilder.CHARACTERIZATION_DOT_SEPARATORS}]", original_name):
+            parts = re.split(f"[ {PromptBuilder.CHARACTERIZATION_DOT_SEPARATORS}]+", original_name)
+        else:
+            parts = [original_name]
+
+        return [part.strip() for part in parts if part.strip()]
+
+    # 优先匹配全名，避免只命中姓或名时漏掉另一半
+    def _build_characterization_full_name_pattern(original_name: str, keywords: list[str]) -> str:
+        if not keywords:
+            return ""
+
+        if len(keywords) == 1:
+            return re.escape(keywords[0])
+
+        if "[Separator]" in original_name:
+            separator_pattern = f"[ {PromptBuilder.CHARACTERIZATION_DOT_SEPARATORS}]*"
+        else:
+            separator_pattern = f"[ {PromptBuilder.CHARACTERIZATION_DOT_SEPARATORS}]+"
+
+        return separator_pattern.join(re.escape(keyword) for keyword in keywords)
+
+    # [Separator] 命中全名后，需要去掉文本里的可见分隔符再回填原名
+    def _normalize_characterization_full_match(original_name: str, matched_text: str) -> str:
+        if "[Separator]" not in original_name:
+            return matched_text
+
+        parts = re.split(f"[ {PromptBuilder.CHARACTERIZATION_DOT_SEPARATORS}]+", matched_text)
+        return "".join(part for part in parts if part)
+
+    # 尝试整名匹配；失败后按关键词匹配，并保留文本里的实际大小写
+    def _match_characterization_original_name(original_name: str, full_text: str) -> str | None:
+        keywords = PromptBuilder._split_characterization_name(original_name)
+        if not keywords or not full_text:
+            return None
+
+        full_name_pattern = PromptBuilder._build_characterization_full_name_pattern(original_name, keywords)
+        if full_name_pattern:
+            full_match = re.search(full_name_pattern, full_text, re.IGNORECASE)
+            if full_match:
+                return PromptBuilder._normalize_characterization_full_match(original_name, full_match.group())
+
+        display_name = original_name.replace("[Separator]", "")
+        is_matched = False
+        for keyword in keywords:
+            match = re.search(re.escape(keyword), full_text, re.IGNORECASE)
+            if not match:
+                continue
+
+            is_matched = True
+            actual_text = match.group()
+            display_name = re.sub(
+                re.escape(keyword),
+                lambda _: actual_text,
+                display_name,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+
+        if is_matched:
+            return display_name
+
+        return None
+
     # 构造角色设定
     def build_characterization(config: TaskConfig, input_dict: dict) -> str:
         dictionary = {}
@@ -722,42 +796,15 @@ class PromptBuilder(Base):
 
         temp_dict = {}
         full_text = "\n".join(input_dict.values())
-        #空格和圆点发送时显示
-        DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
         for key_a, value_a in dictionary.items():
-            keywords = [key_a]
-            if "[Separator]" in key_a:
-                keywords = key_a.split("[Separator]")
-            elif " " in key_a or re.search(f"[{DOT_SEPARATORS}]", key_a):
-                keywords = re.split(f"[ {DOT_SEPARATORS}]+", key_a)
+            matched_name = PromptBuilder._match_characterization_original_name(key_a, full_text)
+            if not matched_name:
+                continue
 
-            keywords = [keyword.strip() for keyword in keywords if keyword.strip()]
-
-            for keyword in keywords:
-                if not keyword:
-                    continue
-
-                # 无视大小写查找匹配部分
-                match = re.search(re.escape(keyword), full_text, re.IGNORECASE)
-                if match:
-                    actual_text = match.group()
-
-                    # 复制配置，避免污染全局数据
-                    new_value = value_a.copy()
-                    orig_name = new_value.get("original_name", "")
-
-                    # 将原名中的对应部分替换为文本里实际的大小写
-                    new_value["original_name"] = re.sub(
-                        re.escape(keyword),
-                        lambda _: actual_text,
-                        orig_name,
-                        count=1,
-                        flags=re.IGNORECASE
-                    )
-
-                    # 存入临时字典，基于 key_a 去重，防止该角色的多个关键词匹配导致重复添加
-                    temp_dict[key_a] = new_value
-                    break
+            # 复制配置后写入命中的原名，避免污染配置，同时按 key_a 去重
+            new_value = value_a.copy()
+            new_value["original_name"] = matched_name
+            temp_dict[key_a] = new_value
 
         if temp_dict == {}:
             return ""
@@ -765,7 +812,7 @@ class PromptBuilder(Base):
         if config.target_language in ("chinese_simplified", "chinese_traditional"):
             profile = "\n###角色介绍"
             for value in temp_dict.values():
-                original_name = value.get("original_name", "").replace("[Separator]", "")
+                original_name = value.get("original_name", "")
                 translated_name = value.get("translated_name")
                 gender = value.get("gender")
                 age = value.get("age")
@@ -790,7 +837,7 @@ class PromptBuilder(Base):
         else:
             profile = "\n###Character Introduction"
             for value in temp_dict.values():
-                original_name = value.get("original_name", "").replace("[Separator]", "")
+                original_name = value.get("original_name", "")
                 translated_name = value.get("translated_name")
                 gender = value.get("gender")
                 age = value.get("age")

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -721,12 +721,14 @@ class PromptBuilder(Base):
             dictionary[item.get("original_name", "")] = item
 
         temp_dict = {}
+        #空格和圆点发送时显示
+        DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
         for key_a, value_a in dictionary.items():
             keywords = [key_a]
             if "[Separator]" in key_a:
                 keywords = key_a.split("[Separator]")
-            elif " " in key_a or "." in key_a:
-                keywords = re.split(r"[ .]", key_a)
+            elif " " in key_a or re.search(f"[{DOT_SEPARATORS}]", key_a):
+                keywords = re.split(f"[ {DOT_SEPARATORS}]+", key_a)
 
             keywords = [keyword.strip() for keyword in keywords if keyword.strip()]
 

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
@@ -311,24 +311,15 @@ class PromptBuilderLocal(Base):
             dictionary[item.get("original_name", "")] = item
 
         temp_dict = {}
+        full_text = "\n".join(source_text_dict.values())
         for original_key, value in dictionary.items():
-            keywords = [original_key]
-            if "[Separator]" in original_key:
-                keywords = original_key.split("[Separator]")
-            elif " " in original_key or "." in original_key:
-                keywords = re.split(r"[ .]", original_key)
+            matched_name = PromptBuilder._match_characterization_original_name(original_key, full_text)
+            if not matched_name:
+                continue
 
-            keywords = [keyword.strip() for keyword in keywords if keyword.strip()]
-
-            is_match = False
-            for source_text in source_text_dict.values():
-                for keyword in keywords:
-                    if keyword and keyword in source_text:
-                        temp_dict[original_key] = value
-                        is_match = True
-                        break
-                if is_match:
-                    break
+            new_value = value.copy()
+            new_value["original_name"] = matched_name
+            temp_dict[original_key] = new_value
 
         if temp_dict == {}:
             return ""
@@ -336,7 +327,7 @@ class PromptBuilderLocal(Base):
         if PromptBuilderLocal._is_chinese_target(config):
             profile = "\n###角色介绍"
             for value in temp_dict.values():
-                original_name = value.get("original_name", "").replace("[Separator]", "")
+                original_name = value.get("original_name", "")
                 translated_name = value.get("translated_name")
                 gender = value.get("gender")
                 age = value.get("age")
@@ -361,7 +352,7 @@ class PromptBuilderLocal(Base):
         else:
             profile = "\n###Character Introduction"
             for value in temp_dict.values():
-                original_name = value.get("original_name", "").replace("[Separator]", "")
+                original_name = value.get("original_name", "")
                 translated_name = value.get("translated_name")
                 gender = value.get("gender")
                 age = value.get("age")
@@ -518,3 +509,4 @@ class PromptBuilderLocal(Base):
         )
 
         return messages, system, extra_log
+        

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
@@ -2,6 +2,7 @@ import re
 from types import SimpleNamespace
 
 from ModuleFolders.Base.Base import Base
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Domain.PromptBuilder.PromptBuilder import PromptBuilder
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderEnum import PromptBuilderEnum
 from ModuleFolders.Infrastructure.TaskConfig.TaskConfig import TaskConfig
@@ -134,38 +135,10 @@ class PromptBuilderLocal(Base):
 
     # 构造术语表
     def build_glossary_prompt(config: TaskConfig, input_dict: dict) -> str:
-        full_text = "\n".join(input_dict.values())
-        result = []
-        seen_keys = set()
-
-        for item in getattr(config, "prompt_dictionary_data", []):
-            src = item.get("src", "")
-            if not src:
-                continue
-
-            try:
-                pattern = re.compile(src, re.IGNORECASE)
-                found_texts = set(match.group() for match in pattern.finditer(full_text))
-                for match_text in found_texts:
-                    if not match_text:
-                        continue
-
-                    key = (match_text, item.get("dst"))
-                    if key in seen_keys:
-                        continue
-
-                    new_entry = item.copy()
-                    new_entry["src"] = match_text
-                    result.append(new_entry)
-                    seen_keys.add(key)
-            except re.error:
-                if src.lower() in full_text.lower():
-                    key = (src, item.get("dst"))
-                    if key in seen_keys:
-                        continue
-
-                    result.append(item)
-                    seen_keys.add(key)
+        result = GlossaryHelper.collect_matched_rows(
+            getattr(config, "prompt_dictionary_data", []),
+            input_dict,
+        )
 
         if not result:
             return ""

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderPolishing.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderPolishing.py
@@ -1,6 +1,7 @@
 import re
 
 from ModuleFolders.Base.Base import Base
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Domain.PromptBuilder.PromptBuilder import PromptBuilder
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderEnum import PromptBuilderEnum
 from ModuleFolders.Infrastructure.TaskConfig.TaskConfig import TaskConfig
@@ -21,39 +22,10 @@ class PromptBuilderPolishing(Base):
         return PromptBuilderPolishing.get_system_default(config)
 
     def build_glossary_prompt(config: TaskConfig, input_dict: dict) -> str:
-        full_text = "\n".join(input_dict.values())
-
-        result = []
-        seen_keys = set()
-
-        for item in config.prompt_dictionary_data:
-            src = item.get("src", "")
-            if not src:
-                continue
-
-            try:
-                pattern = re.compile(src, re.IGNORECASE)
-                found_texts = {match.group() for match in pattern.finditer(full_text)}
-
-                for match_text in found_texts:
-                    if not match_text:
-                        continue
-
-                    key = (match_text, item.get("dst"))
-                    if key in seen_keys:
-                        continue
-
-                    new_entry = item.copy()
-                    new_entry["src"] = match_text
-                    result.append(new_entry)
-                    seen_keys.add(key)
-
-            except re.error:
-                if src.lower() in full_text.lower():
-                    key = (src, item.get("dst"))
-                    if key not in seen_keys:
-                        result.append(item)
-                        seen_keys.add(key)
+        result = GlossaryHelper.collect_matched_rows(
+            getattr(config, "prompt_dictionary_data", []),
+            input_dict,
+        )
 
         if not result:
             return ""

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderSakura.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderSakura.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Infrastructure.TaskConfig.TaskConfig import TaskConfig
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Domain.PromptBuilder.PromptBuilder import PromptBuilder
 
 class PromptBuilderSakura(Base):
@@ -44,45 +45,10 @@ class PromptBuilderSakura(Base):
 
     # 构造术语表
     def build_glossary(config: TaskConfig, input_dict: dict) -> str:
-        # 将输入字典中的所有值合并为一个字符串，方便正则全局匹配
-        full_text = "\n".join(input_dict.values())
-
-        # 筛选并处理匹配的条目
-        result = []
-        seen_keys = set() # 用于去重 (匹配到的实际原文, 译文)
-
-        for v in config.prompt_dictionary_data:
-            src = v.get("src", "")
-            if not src:
-                continue
-
-            try:
-                # 编译正则表达式，忽略大小写以保持与原逻辑一致的宽松匹配
-                pattern = re.compile(src, re.IGNORECASE)
-
-                # 查找所有匹配项 (set去重，处理同一词在文中多次出现的情况)
-                found_texts = set(m.group() for m in pattern.finditer(full_text))
-
-                # 如果正则匹配到了内容 (例如正则 (A|B) 匹配到了 A 和 B，这里会循环两次)
-                for match_text in found_texts:
-                    if not match_text: continue
-
-                    # 使用 (实际匹配文本, 译文) 作为唯一键进行去重
-                    key = (match_text, v.get("dst"))
-                    if key not in seen_keys:
-                        # 复制元数据，并将 src 替换为实际匹配到的原文文本
-                        new_entry = v.copy()
-                        new_entry["src"] = match_text
-                        result.append(new_entry)
-                        seen_keys.add(key)
-
-            except re.error:
-                # 如果正则编译失败（非合法正则），回退到普通字符串包含判断
-                if src.lower() in full_text.lower():
-                    key = (src, v.get("dst"))
-                    if key not in seen_keys:
-                        result.append(v)
-                        seen_keys.add(key)
+        result = GlossaryHelper.collect_matched_rows(
+            getattr(config, "prompt_dictionary_data", []),
+            input_dict,
+        )
 
         if len(result) == 0:
             return ""

--- a/ModuleFolders/Service/SimpleExecutor/SimpleExecutor.py
+++ b/ModuleFolders/Service/SimpleExecutor/SimpleExecutor.py
@@ -14,6 +14,7 @@ from ModuleFolders.Domain.ResponseExtractor.ResponseExtractor import ResponseExt
 from ModuleFolders.Domain.ResponseChecker.ResponseChecker import ResponseChecker
 from ModuleFolders.Domain.PromptBuilder.PromptBuilder import PromptBuilder
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderPolishing import PromptBuilderPolishing
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Service.Cache.CacheItem import TranslationStatus
 
 # 简易请求器
@@ -187,8 +188,11 @@ class SimpleExecutor(ConfigMixin, LogMixin, Base):
             })
             return
 
-        # 获取未翻译术语
-        untranslated_items = [item for item in prompt_dictionary_data if not item.get("dst")]
+        # 获取未翻译术语，编译失败的正则只保留在表格中。
+        untranslated_items = [
+            item for item in prompt_dictionary_data
+            if not item.get("dst") and GlossaryHelper.is_row_valid(item)
+        ]
         if not untranslated_items:
             self.info("没有需要翻译的术语")
             self.emit(Base.EVENT.GLOSS_TASK_DONE, {

--- a/ModuleFolders/Service/TranslationChecker/TerminologyChecker.py
+++ b/ModuleFolders/Service/TranslationChecker/TerminologyChecker.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Config.Config import ConfigMixin
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Log.Log import LogMixin
 from ModuleFolders.Service.Cache.CacheManager import CacheManager
 from ModuleFolders.Service.Cache.CacheItem import TranslationStatus
@@ -49,17 +50,20 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
         analysis_data = self._get_project_analysis_data()
 
         row_sources = (
-            (analysis_data.get("characters", []), "source", "recommended_translation"),
-            (analysis_data.get("terms", []), "source", "recommended_translation"),
-            (self.config.get("prompt_dictionary_data", []), "src", "dst"),
+            (analysis_data.get("characters", []), "source", "recommended_translation", "project"),
+            (analysis_data.get("terms", []), "source", "recommended_translation", "project"),
+            (GlossaryHelper.normalize_rows(self.config.get("prompt_dictionary_data", [])), "src", "dst", "glossary"),
         )
 
-        for rows, source_field, target_field in row_sources:
+        for rows, source_field, target_field, row_type in row_sources:
             if not isinstance(rows, list):
                 continue
 
             for row in rows:
                 if not isinstance(row, dict):
+                    continue
+
+                if row_type == "glossary" and not GlossaryHelper.is_row_valid(row):
                     continue
 
                 src_term = self._normalize_identity(row.get(source_field))
@@ -70,6 +74,8 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
                 merged_rows.append({
                     "src": src_term,
                     "dst": dst_term,
+                    "row_type": row_type,
+                    GlossaryHelper.VALID_KEY: row.get(GlossaryHelper.VALID_KEY, True),
                 })
                 seen_sources.add(src_term)
 
@@ -84,10 +90,26 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
             if not src_term or not dst_term:
                 continue
 
+            if term.get("row_type") == "glossary":
+                pattern = GlossaryHelper.build_search_pattern(
+                    src_term,
+                    term.get(GlossaryHelper.VALID_KEY),
+                )
+                if pattern is None:
+                    continue
+
+                term_data.append({
+                    "type": "pattern",
+                    "pattern": pattern,
+                    "src": src_term,
+                    "dst": dst_term,
+                })
+                continue
+
             try:
                 pattern = re.compile(src_term, re.IGNORECASE)
                 term_data.append({
-                    "type": "regex",
+                    "type": "pattern",
                     "pattern": pattern,
                     "src": src_term,
                     "dst": dst_term,
@@ -148,7 +170,7 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
         for term_item in prepared_data:
             match_found = False
 
-            if term_item["type"] == "regex":
+            if term_item["type"] == "pattern":
                 if term_item["pattern"].search(src):
                     match_found = True
             else:

--- a/ModuleFolders/Service/TranslationChecker/TerminologyChecker.py
+++ b/ModuleFolders/Service/TranslationChecker/TerminologyChecker.py
@@ -49,6 +49,7 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
         seen_sources = set()
         analysis_data = self._get_project_analysis_data()
 
+        # 项目分析术语保持旧格式；公共术语表额外携带正则有效性。
         row_sources = (
             (analysis_data.get("characters", []), "source", "recommended_translation", "project"),
             (analysis_data.get("terms", []), "source", "recommended_translation", "project"),
@@ -63,6 +64,7 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
                 if not isinstance(row, dict):
                     continue
 
+                # 无效公共术语只在 UI 标红，不参与一致性检查。
                 if row_type == "glossary" and not GlossaryHelper.is_row_valid(row):
                     continue
 
@@ -90,6 +92,7 @@ class TerminologyChecker(ConfigMixin, LogMixin, Base):
             if not src_term or not dst_term:
                 continue
 
+            # 公共术语复用术语表匹配规则：正则沿用 regex 默认大小写，普通词忽略大小写。
             if term.get("row_type") == "glossary":
                 pattern = GlossaryHelper.build_search_pattern(
                     src_term,

--- a/UserInterface/EditView/Analysis/AnalysisPage.py
+++ b/UserInterface/EditView/Analysis/AnalysisPage.py
@@ -36,6 +36,7 @@ from qfluentwidgets import (
 
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Config.Config import ConfigMixin
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Log.Log import LogMixin
 from UserInterface.Widget.Toast import ToastMixin
 
@@ -1291,7 +1292,7 @@ class AnalysisPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                 current_rows.append(row)
                 existing_keys.add(row_key)
                 added_count += 1
-            config["prompt_dictionary_data"] = current_rows
+            config["prompt_dictionary_data"] = GlossaryHelper.normalize_rows(current_rows)
 
         if added_count <= 0:
             self.info_toast(self.tra("提示"), self.tra("当前内容均已存在于公共表中。"))

--- a/UserInterface/EditView/Analysis/AnalysisPage.py
+++ b/UserInterface/EditView/Analysis/AnalysisPage.py
@@ -1292,6 +1292,7 @@ class AnalysisPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                 current_rows.append(row)
                 existing_keys.add(row_key)
                 added_count += 1
+            # 写入公共术语表时补齐 is_valid，导出仍只保留用户可编辑列。
             config["prompt_dictionary_data"] = GlossaryHelper.normalize_rows(current_rows)
 
         if added_count <= 0:

--- a/UserInterface/Table/PromptDictionaryPage.py
+++ b/UserInterface/Table/PromptDictionaryPage.py
@@ -23,6 +23,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
     KEYS = ("src", "dst", "info",)
     COLUMN_NAMES = {0: "原文",1: "译文",2: "描述",}
+    # 只在正则编译失败时标红，保存本身不拦截。
     INVALID_ROW_BRUSH = QBrush(QColor(255, 0, 0, 96))
 
     def __init__(self, text: str, window: AppFluentWindow) -> None:
@@ -465,9 +466,20 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
         self._update_search_ui() # 更新标签和按钮状态
 
     def _load_table_rows(self) -> list[dict]:
+        # 表格只展示三列；内部有效性由保存/刷新时重新计算。
         return GlossaryHelper.normalize_rows(
             TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
         )
+
+    def _get_translatable_rows(self, rows: list[dict] | None = None) -> list[dict]:
+        normalized_rows = GlossaryHelper.normalize_rows(
+            self._load_table_rows() if rows is None else rows
+        )
+        # 无效正则不送入简单翻译，避免失败项污染批量任务。
+        return [
+            row for row in normalized_rows
+            if row.get("src") and not row.get("dst") and GlossaryHelper.is_row_valid(row)
+        ]
 
     def _update_table_rows(self, rows: list[dict] | None) -> None:
         normalized_rows = GlossaryHelper.normalize_rows(rows)
@@ -488,6 +500,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
         for row_index in range(self.table.rowCount()):
             first_item = self.table.item(row_index, 0)
             src = first_item.text().strip() if isinstance(first_item, QTableWidgetItem) else ""
+            # is_valid 不展示在表格中，通过原文列回查对应状态。
             is_invalid = bool(src) and not validity_by_src.get(src, True)
             self._set_row_highlight(row_index, is_invalid)
 
@@ -504,6 +517,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
         config = self.load_config()
         config["prompt_dictionary_data"] = self._load_table_rows()
         self.save_config(config)
+        # 立即重绘一次，让刚输入的非法正则马上变红。
         self._update_table_rows(config["prompt_dictionary_data"])
         self.success_toast("", self.tra("数据已保存") + " ... ")
 
@@ -548,6 +562,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
         # 更新并保存
         # 合并现有数据（来自表格状态）+ 新的已过滤数据
+        # 导入数据不信任外部状态，统一按当前 src 重新编译。
         combined_data = GlossaryHelper.normalize_rows(current_data + new_data_filtered)
         config["prompt_dictionary_data"] = combined_data # 直接更新配置
 
@@ -563,6 +578,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
     # 导出方法
     def export_data(self) -> None:
+        # 导出只保留用户可编辑列，is_valid 属于本地运行状态。
         data = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
         if not data:
             self.warning_toast("", self.tra("表格中没有数据可导出"))
@@ -630,6 +646,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                 self.info_toast(self.tra("信息"), self.tra("均已存在于术语表中"))
                 return
 
+            # 角色提取结果同样按术语表规则补齐有效性状态。
             combined_data = GlossaryHelper.normalize_rows(current_data + new_data_filtered)
             config["prompt_dictionary_data"] = combined_data
 
@@ -649,10 +666,12 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
     def glossary_translation(self) -> None:
         if Base.work_status == Base.STATUS.IDLE:
             Base.work_status = Base.STATUS.GLOSS_TASK
+            glossary_rows = self._load_table_rows()
+            translatable_rows = self._get_translatable_rows(glossary_rows)
             data = {}
-            data["prompt_dictionary_data"] = self._load_table_rows()
+            data["prompt_dictionary_data"] = glossary_rows
 
-            if not any(item.get('src') and not item.get('dst') for item in data["prompt_dictionary_data"]):
+            if not translatable_rows:
                     self.info_toast(self.tra("提示"), self.tra("没有需要翻译的术语"))
                     Base.work_status = Base.STATUS.IDLE
                     return

--- a/UserInterface/Table/PromptDictionaryPage.py
+++ b/UserInterface/Table/PromptDictionaryPage.py
@@ -5,11 +5,13 @@ from qfluentwidgets import (Action, FluentIcon, MessageBox, TableWidget, RoundMe
                             LineEdit, DropDownPushButton, ToolButton, TransparentPushButton, TransparentToolButton, BodyLabel)
 
 from PyQt5.QtCore import QEvent, Qt, QPoint, QTimer
+from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtWidgets import ( QFrame, QFileDialog, QHeaderView, QLayout, QVBoxLayout,
                              QTableWidgetItem, QHBoxLayout, QWidget,QAbstractItemView)
 
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Config.Config import ConfigMixin
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Log.Log import LogMixin
 from UserInterface.Widget.Toast import ToastMixin
 from UserInterface.Table.TableHelper.TableHelper import TableHelper
@@ -21,6 +23,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
     KEYS = ("src", "dst", "info",)
     COLUMN_NAMES = {0: "原文",1: "译文",2: "描述",}
+    INVALID_ROW_BRUSH = QBrush(QColor(255, 0, 0, 96))
 
     def __init__(self, text: str, window: AppFluentWindow) -> None:
         super().__init__(parent=window)
@@ -71,7 +74,8 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
     # 更新表格内容及状态
     def update_table(self) -> None:
         config = self.load_config()
-        TableHelper.update_to_table(self.table, config["prompt_dictionary_data"], PromptDictionaryPage.KEYS)
+        rows = GlossaryHelper.normalize_rows(config.get("prompt_dictionary_data", []))
+        self._update_table_rows(rows)
         self._reset_search()
         self._reset_sort_indicator()
 
@@ -460,11 +464,47 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
         self._update_search_ui() # 更新标签和按钮状态
 
+    def _load_table_rows(self) -> list[dict]:
+        return GlossaryHelper.normalize_rows(
+            TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+        )
+
+    def _update_table_rows(self, rows: list[dict] | None) -> None:
+        normalized_rows = GlossaryHelper.normalize_rows(rows)
+        self.table.setRowCount(0)
+        TableHelper.update_to_table(self.table, normalized_rows, PromptDictionaryPage.KEYS)
+        self.table.resizeRowsToContents()
+        self._refresh_invalid_row_highlight(normalized_rows)
+
+    def _refresh_invalid_row_highlight(self, rows: list[dict] | None) -> None:
+        validity_by_src = {}
+        for row in rows or []:
+            src = str(row.get("src", "") or "").strip()
+            if not src:
+                continue
+
+            validity_by_src[src] = bool(row.get(GlossaryHelper.VALID_KEY, True))
+
+        for row_index in range(self.table.rowCount()):
+            first_item = self.table.item(row_index, 0)
+            src = first_item.text().strip() if isinstance(first_item, QTableWidgetItem) else ""
+            is_invalid = bool(src) and not validity_by_src.get(src, True)
+            self._set_row_highlight(row_index, is_invalid)
+
+    def _set_row_highlight(self, row_index: int, highlighted: bool) -> None:
+        for column_index in range(self.table.columnCount()):
+            item = self.table.item(row_index, column_index)
+            if not isinstance(item, QTableWidgetItem):
+                continue
+
+            item.setBackground(self.INVALID_ROW_BRUSH if highlighted else QBrush())
+
     # 保存方法
     def save_data(self) -> None:
         config = self.load_config()
-        config["prompt_dictionary_data"] = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+        config["prompt_dictionary_data"] = self._load_table_rows()
         self.save_config(config)
+        self._update_table_rows(config["prompt_dictionary_data"])
         self.success_toast("", self.tra("数据已保存") + " ... ")
 
     # 重置方法
@@ -481,8 +521,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
         config = self.load_config()
         config["prompt_dictionary_data"] = copy.deepcopy(self.default.get("prompt_dictionary_data", []))
         self.save_config(config)
-        TableHelper.update_to_table(self.table, config.get("prompt_dictionary_data"), PromptDictionaryPage.KEYS)
-        self.table.resizeRowsToContents()
+        self._update_table_rows(config.get("prompt_dictionary_data"))
         self._reset_search() # 重置后重置搜索
         self._reset_sort_indicator() # 重置后重置排序
         self.success_toast("", self.tra("数据已重置") + " ... ")
@@ -509,15 +548,14 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
 
         # 更新并保存
         # 合并现有数据（来自表格状态）+ 新的已过滤数据
-        combined_data = current_data + new_data_filtered
+        combined_data = GlossaryHelper.normalize_rows(current_data + new_data_filtered)
         config["prompt_dictionary_data"] = combined_data # 直接更新配置
 
         # 在再次从表格保存配置*之前*更新表格
-        TableHelper.update_to_table(self.table, config["prompt_dictionary_data"], PromptDictionaryPage.KEYS)
-        self.table.resizeRowsToContents() # 导入后调整行高
+        self._update_table_rows(config["prompt_dictionary_data"])
 
         # 现在将可能已修改的表格状态保存回配置
-        config["prompt_dictionary_data"] = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+        config["prompt_dictionary_data"] = self._load_table_rows()
         self.save_config(config)
         self._reset_search() # 导入后重置搜索
         self._reset_sort_indicator() # 导入后重置排序
@@ -592,13 +630,12 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                 self.info_toast(self.tra("信息"), self.tra("均已存在于术语表中"))
                 return
 
-            combined_data = current_data + new_data_filtered
+            combined_data = GlossaryHelper.normalize_rows(current_data + new_data_filtered)
             config["prompt_dictionary_data"] = combined_data
 
-            TableHelper.update_to_table(self.table, config["prompt_dictionary_data"], PromptDictionaryPage.KEYS)
-            self.table.resizeRowsToContents()
+            self._update_table_rows(config["prompt_dictionary_data"])
 
-            config["prompt_dictionary_data"] = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+            config["prompt_dictionary_data"] = self._load_table_rows()
             self.save_config(config)
             self._reset_search()
             self._reset_sort_indicator()
@@ -613,7 +650,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
         if Base.work_status == Base.STATUS.IDLE:
             Base.work_status = Base.STATUS.GLOSS_TASK
             data = {}
-            data["prompt_dictionary_data"] = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+            data["prompt_dictionary_data"] = self._load_table_rows()
 
             if not any(item.get('src') and not item.get('dst') for item in data["prompt_dictionary_data"]):
                     self.info_toast(self.tra("提示"), self.tra("没有需要翻译的术语"))
@@ -643,7 +680,7 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                 self.warning_toast(self.tra("完成"), self.tra("翻译完成，但没有数据被更新"))
                 return
 
-            prompt_dictionary_data_table = TableHelper.load_from_table(self.table, PromptDictionaryPage.KEYS)
+            prompt_dictionary_data_table = self._load_table_rows()
             updated_map = {item['src']: item['dst'] for item in updated_data if item.get('src') and item.get('dst')}
 
             something_updated = False
@@ -655,9 +692,9 @@ class PromptDictionaryPage(QFrame, ConfigMixin, LogMixin, ToastMixin, Base):
                     something_updated = True
 
             if something_updated:
+                prompt_dictionary_data_table = GlossaryHelper.normalize_rows(prompt_dictionary_data_table)
                 self.table.setUpdatesEnabled(False)
-                TableHelper.update_to_table(self.table, prompt_dictionary_data_table, PromptDictionaryPage.KEYS)
-                self.table.resizeRowsToContents()
+                self._update_table_rows(prompt_dictionary_data_table)
                 self.table.setUpdatesEnabled(True)
 
                 config = self.load_config()


### PR DESCRIPTION
大概改动是：
用的regex
默认无视大小写[以前是强制无视大小写]
无视大小写时，发送匹配原文大小写
有正则就大小写敏感[符合使用正则的直觉]
术语表保存时编译正则，错误该行标红，且任务无视标红术语
配置上给每个术语加了布尔值持久化，但不影响导入/导出

合了我在把这部分wiki重写下，因为上个pr是在主线做的，没办法就只能切个分支在交了，这个改的有点多
