### PR TITLE
人物匹配规则调整

### DIFF
--- a/ModuleFolders/Domain/PromptBuilder/CharacterHelper.py
+++ b/ModuleFolders/Domain/PromptBuilder/CharacterHelper.py
@@ -4,13 +4,23 @@ import regex._regex_core
 
 class CharacterHelper:
     VALID_KEY = "is_valid"
+    SEPARATOR_TOKEN = "[Separator]"
     DOT_SEPARATORS = r".．・·･∙⋅‧⸱﹒。｡"
-    
+    SPACE_SEPARATOR = " "
+    SPACE_SEPARATORS = " \t\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000"
+    ZERO_WIDTH_CHARS = "\u200b\u200c\u200d\u2060\ufeff"
+
     @staticmethod
     def _normalize_text(value) -> str:
         if value is None:
             return ""
-        return str(value).strip()
+        zero_width_translation = str.maketrans("", "", CharacterHelper.ZERO_WIDTH_CHARS)
+        return str(value).translate(zero_width_translation).strip()
+
+    @classmethod
+    def _normalize_name(cls, value) -> str:
+        name = cls._normalize_text(value)
+        return re.sub(f"[{re.escape(cls.SPACE_SEPARATORS)}]+", cls.SPACE_SEPARATOR, name)
 
     @staticmethod
     def _parse_source_text(source_text: str):
@@ -69,14 +79,128 @@ class CharacterHelper:
         return literal_text != source_text
 
     @classmethod
+    def _match_separator_at(cls, name: str, start: int) -> tuple[str, int] | None:
+        if name.startswith(cls.SEPARATOR_TOKEN, start):
+            return cls.SEPARATOR_TOKEN, len(cls.SEPARATOR_TOKEN)
+
+        char = name[start]
+        if char in cls.SPACE_SEPARATORS or char in cls.DOT_SEPARATORS:
+            return char, 1
+
+        return None
+
+    @classmethod
+    def _has_consecutive_separators(cls, name: str) -> bool:
+        previous_is_separator = False
+        index = 0
+        while index < len(name):
+            separator = cls._match_separator_at(name, index)
+            if separator:
+                if previous_is_separator:
+                    return True
+                previous_is_separator = True
+                index += separator[1]
+                continue
+
+            previous_is_separator = False
+            index += 1
+
+        return False
+
+    @classmethod
+    def _has_edge_separator(cls, name: str) -> bool:
+        if not name:
+            return False
+
+        if cls._match_separator_at(name, 0):
+            return True
+
+        parts, _ = cls._parse_name(name)
+        return bool(parts and not parts[-1])
+
+    @classmethod
+    def _parse_name(cls, original_name: str) -> tuple[list[str], list[str]]:
+        parts = []
+        separators = []
+        current_part = []
+        index = 0
+
+        while index < len(original_name):
+            separator = cls._match_separator_at(original_name, index)
+            if separator:
+                parts.append("".join(current_part).strip())
+                separators.append(separator[0])
+                current_part = []
+                index += separator[1]
+                continue
+
+            current_part.append(original_name[index])
+            index += 1
+
+        parts.append("".join(current_part).strip())
+        return parts, separators
+
+    @classmethod
+    def _match_separator_pattern(cls, allow_empty: bool) -> str:
+        token_pattern = re.escape(cls.SEPARATOR_TOKEN)
+        char_pattern = f"[{re.escape(cls.SPACE_SEPARATORS + cls.DOT_SEPARATORS)}]"
+        separator_pattern = f"(?:{token_pattern}|{char_pattern})"
+        return f"{separator_pattern}?" if allow_empty else separator_pattern
+
+    @classmethod
+    def _display_separator(cls, separator: str) -> str:
+        if separator == cls.SEPARATOR_TOKEN:
+            return ""
+        if separator in cls.SPACE_SEPARATORS:
+            return cls.SPACE_SEPARATOR
+        return separator
+
+    @classmethod
+    def _build_display_name(cls, original_name: str, matched_parts: list[str] | None = None) -> str:
+        parts, separators = cls._parse_name(original_name)
+        matched_parts = matched_parts or []
+        display_name = ""
+
+        for index, part in enumerate(parts):
+            if part:
+                display_name += matched_parts[index] if index < len(matched_parts) else part
+            if index < len(separators):
+                display_name += cls._display_separator(separators[index])
+
+        return display_name
+
+    @classmethod
+    def _build_full_name_match_pattern(cls, original_name: str) -> str:
+        parts, separators = cls._parse_name(original_name)
+        if not parts or any(not part for part in parts):
+            return ""
+
+        pattern = f"({re.escape(parts[0])})"
+        for index, separator in enumerate(separators):
+            if index + 1 >= len(parts):
+                break
+
+            pattern += cls._match_separator_pattern(separator == cls.SEPARATOR_TOKEN)
+            pattern += f"({re.escape(parts[index + 1])})"
+
+        return pattern
+
+    @classmethod
     def validate_name(cls, name: str) -> bool:
-        name = cls._normalize_text(name)
+        name = cls._normalize_name(name)
         if not name:
             return True
+
+        if cls._has_edge_separator(name):
+            return False
+
+        if cls._has_consecutive_separators(name):
+            return False
             
         # 允许的分隔符暂时替换为普通字符，以避免被误判为正则
-        test_name = name.replace("[Separator]", "X")
-        test_name = test_name.replace(" ", "X")
+        test_name = name.replace(cls.SEPARATOR_TOKEN, "X")
+        for space in cls.SPACE_SEPARATORS:
+            test_name = test_name.replace(space, "X")
         for dot in cls.DOT_SEPARATORS:
             test_name = test_name.replace(dot, "X")
             
@@ -90,7 +214,7 @@ class CharacterHelper:
     def normalize_row(cls, row: dict) -> dict:
         # 持久化校验结果，UI 与任务流程复用同一份有效性判断。
         normalized_row = dict(row) if isinstance(row, dict) else {}
-        name = cls._normalize_text(normalized_row.get("original_name", ""))
+        name = cls._normalize_name(normalized_row.get("original_name", ""))
         normalized_row["original_name"] = name
         # 补充其它的字段，确保一致性
         for key in ["translated_name", "gender", "age", "personality", "speech_style", "additional_info"]:
@@ -110,42 +234,46 @@ class CharacterHelper:
             normalized_rows.append(cls.normalize_row(row))
         return normalized_rows
 
-    @staticmethod
-    def split_name(original_name: str) -> list[str]:
+    @classmethod
+    def split_name(cls, original_name: str) -> list[str]:
         if not original_name:
             return []
 
-        if "[Separator]" in original_name:
-            parts = original_name.split("[Separator]")
-        elif " " in original_name or re.search(f"[{CharacterHelper.DOT_SEPARATORS}]", original_name):
-            parts = re.split(f"[ {CharacterHelper.DOT_SEPARATORS}]+", original_name)
-        else:
-            parts = [original_name]
-
+        parts, _ = cls._parse_name(original_name)
         return [part.strip() for part in parts if part.strip()]
 
-    @staticmethod
-    def build_full_name_pattern(original_name: str, keywords: list[str]) -> str:
+    @classmethod
+    def build_full_name_pattern(cls, original_name: str, keywords: list[str]) -> str:
         if not keywords:
             return ""
 
-        if len(keywords) == 1:
-            return re.escape(keywords[0])
+        parts, separators = cls._parse_name(original_name)
+        if not parts or any(not part for part in parts):
+            return ""
 
-        if "[Separator]" in original_name:
-            separator_pattern = f"[ {CharacterHelper.DOT_SEPARATORS}]*"
-        else:
-            separator_pattern = f"[ {CharacterHelper.DOT_SEPARATORS}]+"
+        if len(parts) == 1:
+            return re.escape(parts[0])
 
-        return separator_pattern.join(re.escape(keyword) for keyword in keywords)
+        pattern = re.escape(parts[0])
+        for index, separator in enumerate(separators):
+            if index + 1 >= len(parts):
+                break
+            pattern += cls._match_separator_pattern(separator == cls.SEPARATOR_TOKEN)
+            pattern += re.escape(parts[index + 1])
 
-    @staticmethod
-    def normalize_full_match(original_name: str, matched_text: str) -> str:
-        if "[Separator]" not in original_name:
+        return pattern
+
+    @classmethod
+    def normalize_full_match(cls, original_name: str, matched_text: str) -> str:
+        full_name_pattern = cls._build_full_name_match_pattern(original_name)
+        if not full_name_pattern:
             return matched_text
 
-        parts = re.split(f"[ {CharacterHelper.DOT_SEPARATORS}]+", matched_text)
-        return "".join(part for part in parts if part)
+        full_match = re.fullmatch(full_name_pattern, matched_text, re.IGNORECASE)
+        if not full_match:
+            return cls._build_display_name(original_name)
+
+        return cls._build_display_name(original_name, list(full_match.groups()))
 
     @classmethod
     def match_original_name(cls, original_name: str, full_text: str, is_valid: bool = True) -> str | None:
@@ -156,13 +284,13 @@ class CharacterHelper:
         if not keywords or not full_text:
             return None
 
-        full_name_pattern = cls.build_full_name_pattern(original_name, keywords)
+        full_name_pattern = cls._build_full_name_match_pattern(original_name)
         if full_name_pattern:
             full_match = re.search(full_name_pattern, full_text, re.IGNORECASE)
             if full_match:
-                return cls.normalize_full_match(original_name, full_match.group())
+                return cls._build_display_name(original_name, list(full_match.groups()))
 
-        display_name = original_name.replace("[Separator]", "")
+        display_name = cls._build_display_name(original_name)
         is_matched = False
         for keyword in keywords:
             match = re.search(re.escape(keyword), full_text, re.IGNORECASE)


### PR DESCRIPTION
现在规则是：
连续分隔符非法
首尾分隔符非法
正则非法
匹配不区分大小写，发送时保留文中实际大小写
检查是：首尾的空格会被清理到非空格的字符，中间转为普通单空格并开始检查，清理也呈现在用户ui上
全局清理零宽字符
空格类做和点类一样的宽泛匹配