### PR TITLE
fix: 收集懒加载文件读写模块

### DIFF
--- a/Tools/pyinstall.py
+++ b/Tools/pyinstall.py
@@ -17,6 +17,10 @@ cmd = [
     "--collect-all=rich",
     "--collect-all=bitstring",
     "--collect-all=darkdetect",
+    # FileReader/FileOutputer use importlib-based lazy loading; collect their
+    # submodules so packaged builds can load formats at runtime.
+    "--collect-submodules=ModuleFolders.Domain.FileReader",
+    "--collect-submodules=ModuleFolders.Domain.FileOutputer",
     # "--distpath=./dist/AiNiee" #指定输出目录
 ]
 

--- a/Tools/pyinstall_macos.py
+++ b/Tools/pyinstall_macos.py
@@ -152,6 +152,10 @@ def pyinstaller_command(icon_path: Path, arch: str | None = None) -> list[str]:
         "--collect-all=objc",
         "--collect-all=Foundation",
         "--collect-all=AppKit",
+        # FileReader/FileOutputer use importlib-based lazy loading; collect
+        # their submodules so packaged builds can load formats at runtime.
+        "--collect-submodules=ModuleFolders.Domain.FileReader",
+        "--collect-submodules=ModuleFolders.Domain.FileOutputer",
         "--exclude-module=jaxlib",
         "--exclude-module=win32com",
         "--exclude-module=pythoncom",


### PR DESCRIPTION
## 问题

PR #1027 将具体 FileReader/FileOutputer 改为 importlib 懒加载后，源码运行正常，但 PyInstaller 静态分析无法发现这些字符串形式的动态导入。冻结包里缺少具体读写模块时，运行期加载格式会报错，例如载入 TXT 时出现：

```text
ModuleNotFoundError: No module named 'ModuleFolders.Domain.FileReader.TxtReader'
```

同类问题不只影响 TXT，所有 `_BUILTIN_READERS` / `_BUILTIN_WRITERS` 中按需加载的格式模块都可能在打包版本里缺失。

## 修改

- Windows PyInstaller 构建增加 `--collect-submodules=ModuleFolders.Domain.FileReader`。
- Windows PyInstaller 构建增加 `--collect-submodules=ModuleFolders.Domain.FileOutputer`。
- macOS PyInstaller 构建同步增加上述两个收集项。

这样可以保留 #1027 的启动性能优化，同时让冻结包包含运行期需要动态加载的读写模块。