### PR TITLE
fix: 打包正确收集懒加载的读写模块2

### DIFF
--- a/Tools/pyinstall.py
+++ b/Tools/pyinstall.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import PyInstaller.__main__
 
 cmd = [
@@ -17,6 +18,10 @@ cmd = [
     "--collect-all=rich",
     "--collect-all=bitstring",
     "--collect-all=darkdetect",
+    # FileReader/FileOutputer use importlib-based lazy loading; collect their
+    # submodules so packaged builds can load formats at runtime.
+    "--collect-submodules=ModuleFolders.Domain.FileReader",
+    "--collect-submodules=ModuleFolders.Domain.FileOutputer",
     # "--distpath=./dist/AiNiee" #指定输出目录
 ]
 
@@ -47,4 +52,5 @@ if os.path.exists("./requirements.txt"):
     for pkg in _hidden_imports_from("./requirements_no_deps.txt"):
         cmd.append("--hidden-import=" + pkg)
 
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     PyInstaller.__main__.run(cmd)

--- a/Tools/pyinstall_macos.py
+++ b/Tools/pyinstall_macos.py
@@ -152,6 +152,10 @@ def pyinstaller_command(icon_path: Path, arch: str | None = None) -> list[str]:
         "--collect-all=objc",
         "--collect-all=Foundation",
         "--collect-all=AppKit",
+        # FileReader/FileOutputer use importlib-based lazy loading; collect
+        # their submodules so packaged builds can load formats at runtime.
+        "--collect-submodules=ModuleFolders.Domain.FileReader",
+        "--collect-submodules=ModuleFolders.Domain.FileOutputer",
         "--exclude-module=jaxlib",
         "--exclude-module=win32com",
         "--exclude-module=pythoncom",
@@ -169,6 +173,7 @@ def main() -> None:
     args = parser.parse_args()
 
     os.chdir(ROOT)
+    sys.path.insert(0, str(ROOT))
     icon_path = build_icns()
     PyInstaller.__main__.run(pyinstaller_command(icon_path, args.target_arch))
     patch_info_plist()


### PR DESCRIPTION
大意了 😅 以为小bug就没做实际测试，结果 `--collect-submodules` 不走工作路径，需要用 `sys.path`

*实际测试过，确认没问题了

**这里不能用 `--path` 因为是在 `run()` 时候运行的，但是 `--collect-submodules` 的运行早于其所以会无效