### PR TITLE
优化切分逻辑和缓存支持断点续传

### DIFF
--- a/ModuleFolders/Infrastructure/TaskConfig/TaskConfig.py
+++ b/ModuleFolders/Infrastructure/TaskConfig/TaskConfig.py
@@ -18,6 +18,18 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
     SUPPORTED_INTERFACE_ROLES = {"active", "extract", "translate", "polish", "proofread"}
     API_ROLE_KEYS = ("extract", "translate", "polish", "proofread")
     API_SETTINGS_MIGRATION_KEY = "_active_follow_migration_done"
+    TASK_SPLIT_DEFAULTS = {
+        "lines_limit_switch": False,
+        "tokens_limit_switch": True,
+        "lines_limit": 20,
+        "tokens_limit": 1024,
+        "split_optimization_enable": True,
+        "chunk_soft_limit_extra_lines": 15,
+        "chunk_soft_limit_extra_tokens": 100,
+        "split_optimization_mode": "dynamic",
+        "retry_split_min_lines": 15,
+        "retry_split_min_tokens": 100,
+    }
 
     def __init__(self) -> None:
         super().__init__()
@@ -143,6 +155,37 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
 
         return config
 
+    # 补齐任务切分优化配置，兼容 CLI 版本曾经使用的字段名
+    def _normalize_split_optimization_settings(self, config: dict, persist: bool = False) -> dict:
+        original_config = dict(config)
+
+        legacy_mode = str(config.get("line_split_optimization_mode", "") or "").strip().lower()
+        if "split_optimization_mode" not in config and legacy_mode in {"dynamic", "tail"}:
+            config["split_optimization_mode"] = legacy_mode
+
+        if "split_optimization_enable" not in config and legacy_mode in {"dynamic", "tail"}:
+            config["split_optimization_enable"] = True
+
+        legacy_extra_units = config.get("chunk_soft_limit_extra_units")
+        if "chunk_soft_limit_extra_lines" not in config and legacy_extra_units is not None:
+            config["chunk_soft_limit_extra_lines"] = legacy_extra_units
+
+        legacy_retry_units = config.get("retry_split_min_units")
+        if "retry_split_min_lines" not in config and legacy_retry_units is not None:
+            config["retry_split_min_lines"] = legacy_retry_units
+
+        for key, value in self.TASK_SPLIT_DEFAULTS.items():
+            config.setdefault(key, value)
+
+        mode = str(config.get("split_optimization_mode", "dynamic") or "dynamic").strip().lower()
+        config["split_optimization_mode"] = mode if mode in {"dynamic", "tail"} else "dynamic"
+        config["split_optimization_enable"] = bool(config.get("split_optimization_enable", False))
+
+        if persist and original_config != config:
+            return self.save_config(config)
+
+        return config
+
     # 根据功能角色解析目标接口：优先取角色绑定，取不到则回退到 active
     def resolve_platform_tag_for_role(self, interface_role: str | None = None) -> str | None:
         role = self._normalize_interface_role(interface_role or getattr(self, "interface_role", "active"))
@@ -191,6 +234,7 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
         self.apikey_list = []
 
         config = self._normalize_api_settings(self.load_config(), persist=True)
+        config = self._normalize_split_optimization_settings(config, persist=True)
 
         # 将字典中的每一项赋值到类中的同名属性
         for key, value in config.items():

--- a/ModuleFolders/Service/Cache/CacheItem.py
+++ b/ModuleFolders/Service/Cache/CacheItem.py
@@ -25,6 +25,8 @@ class TranslationStatus:
 
 @dataclass(repr=False)
 class CacheItem(ThreadSafeCache, ExtraMixin):
+    MANUALLY_RESET_EXTRA_KEY: ClassVar[str] = "manually_reset"
+
     # 类级别的 tiktoken 编码器缓存（全局单例）
     _encoding: ClassVar[Optional[Any]] = None
     _encoding_failed: ClassVar[bool] = False
@@ -222,7 +224,21 @@ class CacheItem(ThreadSafeCache, ExtraMixin):
         Returns:
             dict: 额外属性字典
         """
+        if self.extra is None:
+            self.extra = {}
         return self.extra
+
+    def is_manually_reset(self) -> bool:
+        return self.get_extra(self.MANUALLY_RESET_EXTRA_KEY, False) is True
+
+    def mark_manually_reset(self) -> None:
+        self.set_extra(self.MANUALLY_RESET_EXTRA_KEY, True)
+
+    def clear_manually_reset(self) -> None:
+        if not self.extra:
+            return
+
+        self.extra.pop(self.MANUALLY_RESET_EXTRA_KEY, None)
 
     def __repr__(self) -> str:
         """自定义字符串表示（用于调试）"""

--- a/ModuleFolders/Service/Cache/CacheManager.py
+++ b/ModuleFolders/Service/Cache/CacheManager.py
@@ -633,9 +633,14 @@ class CacheManager(ConfigMixin, LogMixin, Base):
                 item.translation_status = TranslationStatus.UNTRANSLATED
 
             if item.translation_status in (TranslationStatus.TRANSLATED, TranslationStatus.POLISHED):
+                item.clear_manually_reset()
                 if not item.translated_text.strip():
                     item.translation_status = TranslationStatus.UNTRANSLATED
-            elif item.translation_status == TranslationStatus.UNTRANSLATED and item.translated_text.strip():
+            elif (
+                item.translation_status == TranslationStatus.UNTRANSLATED
+                and item.translated_text.strip()
+                and not item.is_manually_reset()
+            ):
                 item.translation_status = TranslationStatus.TRANSLATED
 
             if item.translation_status in (TranslationStatus.TRANSLATED, TranslationStatus.POLISHED):
@@ -776,10 +781,12 @@ class CacheManager(ConfigMixin, LogMixin, Base):
                             if item.translation_status not in (TranslationStatus.TRANSLATED, TranslationStatus.POLISHED):
                                 continue
                             item.translation_status = TranslationStatus.UNTRANSLATED
+                            item.mark_manually_reset()
                         elif task_mode == TaskType.POLISH:
                             if item.translation_status != TranslationStatus.POLISHED:
                                 continue
                             item.translation_status = TranslationStatus.TRANSLATED
+                            item.clear_manually_reset()
                         else:
                             return changed_count
 
@@ -1055,8 +1062,10 @@ class CacheManager(ConfigMixin, LogMixin, Base):
                 item_to_update.translated_text = new_text
                 if not new_text or not new_text.strip():
                     item_to_update.translation_status = TranslationStatus.UNTRANSLATED
+                    item_to_update.mark_manually_reset()
                 else:
                     item_to_update.translation_status = TranslationStatus.TRANSLATED
+                    item_to_update.clear_manually_reset()
 
     def update_generated_translation(
         self,
@@ -1076,8 +1085,10 @@ class CacheManager(ConfigMixin, LogMixin, Base):
             item_to_update.translated_text = new_text
             if not new_text or not new_text.strip():
                 item_to_update.translation_status = TranslationStatus.UNTRANSLATED
+                item_to_update.mark_manually_reset()
             else:
                 item_to_update.translation_status = translation_status
+                item_to_update.clear_manually_reset()
 
     def search_items(self, query: str, scope: str, is_regex: bool, search_flagged: bool) -> list:
         """在整个项目缓存中搜索条目。"""

--- a/ModuleFolders/Service/Cache/CacheManager.py
+++ b/ModuleFolders/Service/Cache/CacheManager.py
@@ -38,6 +38,8 @@ class CacheManager(ConfigMixin, LogMixin, Base):
 
         # 线程锁：保护 project 的读写以及缓存落盘过程
         self.file_lock = threading.Lock()
+        self._save_thread_lock = threading.Lock()
+        self._save_thread = None
         self.project = None
         self.save_to_file_stop_flag = False
         self.save_to_file_require_flag = False
@@ -56,11 +58,19 @@ class CacheManager(ConfigMixin, LogMixin, Base):
                 self.load_from_project_id(current_project_id)
 
         self.save_to_file_stop_flag = False
-        threading.Thread(target=self.save_to_file_tick, daemon=True).start()
+        with self._save_thread_lock:
+            if self._save_thread is None or not self._save_thread.is_alive():
+                self._save_thread = threading.Thread(
+                    target=self.save_to_file_tick,
+                    daemon=True,
+                    name="cache-save-tick",
+                )
+                self._save_thread.start()
 
     def app_shut_down(self, event: int, data: dict) -> None:
         """应用关闭时通知保存线程停止。"""
         self.save_to_file_stop_flag = True
+        self.flush_pending_save()
 
     def on_manual_save_cache_requested(self, event: int, data: dict) -> None:
         """处理手动保存缓存请求。"""
@@ -142,6 +152,120 @@ class CacheManager(ConfigMixin, LogMixin, Base):
         except (TypeError, ValueError):
             return 0
 
+    @staticmethod
+    def _normalize_input_path(input_path: str) -> str:
+        if not input_path:
+            return ""
+        try:
+            return str(Path(input_path).expanduser().resolve())
+        except (OSError, RuntimeError):
+            return os.path.abspath(os.path.expanduser(str(input_path)))
+
+    @classmethod
+    def _build_input_fingerprint(cls, input_path: str) -> dict:
+        normalized_input_path = cls._normalize_input_path(input_path)
+        if not normalized_input_path:
+            return {}
+
+        root_path = Path(normalized_input_path)
+        if not root_path.exists():
+            return {}
+
+        base_dir = root_path if root_path.is_dir() else root_path.parent
+        if root_path.is_dir():
+            paths = [path for path in root_path.rglob("*") if path.is_file()]
+        else:
+            paths = [root_path]
+
+        files = []
+        for file_path in sorted(paths, key=lambda item: str(item)):
+            try:
+                stat = file_path.stat()
+                try:
+                    relative_path = str(file_path.relative_to(base_dir))
+                except ValueError:
+                    relative_path = str(file_path)
+                files.append(
+                    {
+                        "path": relative_path.replace("\\", "/"),
+                        "size": stat.st_size,
+                        "mtime_ns": stat.st_mtime_ns,
+                    }
+                )
+            except OSError:
+                continue
+
+        return {
+            "input_path": normalized_input_path,
+            "files": files,
+        }
+
+    @classmethod
+    def _get_project_cache_metadata(cls, project: CacheProject) -> dict:
+        extra = getattr(project, "extra", None)
+        if not isinstance(extra, dict):
+            return {}
+
+        metadata = extra.get("cache_metadata")
+        if isinstance(metadata, dict):
+            return metadata
+
+        return {}
+
+    @classmethod
+    def _set_project_cache_metadata(
+        cls,
+        project: CacheProject,
+        translation_project: str = "",
+        input_path: str = "",
+    ) -> None:
+        if project is None:
+            return
+
+        if not isinstance(getattr(project, "extra", None), dict):
+            project.extra = {}
+
+        normalized_input_path = cls._normalize_input_path(input_path or getattr(project, "input_path", ""))
+        metadata = dict(cls._get_project_cache_metadata(project))
+        metadata["translation_project"] = translation_project or getattr(project, "project_type", "")
+        metadata["input_path"] = normalized_input_path
+        metadata["input_fingerprint"] = cls._build_input_fingerprint(normalized_input_path)
+        project.extra["cache_metadata"] = metadata
+
+        if normalized_input_path:
+            project.input_path = normalized_input_path
+
+    @classmethod
+    def _project_matches_source(
+        cls,
+        project: CacheProject,
+        translation_project: str,
+        input_path: str,
+    ) -> bool:
+        if project is None:
+            return False
+
+        normalized_input_path = cls._normalize_input_path(input_path)
+        if not normalized_input_path:
+            return False
+
+        metadata = cls._get_project_cache_metadata(project)
+        cached_input_path = cls._normalize_input_path(
+            metadata.get("input_path") or getattr(project, "input_path", "")
+        )
+        if cached_input_path != normalized_input_path:
+            return False
+
+        cached_translation_project = metadata.get("translation_project") or getattr(project, "project_type", "")
+        if translation_project and cached_translation_project and cached_translation_project != translation_project:
+            return False
+
+        cached_fingerprint = metadata.get("input_fingerprint")
+        if isinstance(cached_fingerprint, dict) and cached_fingerprint:
+            return cached_fingerprint == cls._build_input_fingerprint(normalized_input_path)
+
+        return False
+
     @classmethod
     def _normalize_progress(
         cls,
@@ -176,10 +300,13 @@ class CacheManager(ConfigMixin, LogMixin, Base):
     ) -> dict:
         """构建写入 ProjectStatistics.json 的内容。"""
         total_line, line, _ = cls._normalize_progress(project, stats_payload)
+        metadata = cls._get_project_cache_metadata(project)
         return {
             "project_id": project.project_id,
             "project_name": project.project_name,
             "project_create_time": project.project_create_time,
+            "translation_project": metadata.get("translation_project") or project.project_type,
+            "input_path": metadata.get("input_path") or project.input_path,
             "total_line": total_line,
             "line": line,
         }
@@ -278,6 +405,8 @@ class CacheManager(ConfigMixin, LogMixin, Base):
         project_create_time = str(stats_payload.get("project_create_time", "")).strip() or cls._timestamp_to_iso(
             os.path.getctime(cache_dir)
         )
+        translation_project = str(stats_payload.get("translation_project", "") or "").strip()
+        input_path = str(stats_payload.get("input_path", "") or "").strip()
         total_line = cls._parse_int(stats_payload.get("total_line", 0))
         line = cls._parse_int(stats_payload.get("line", 0))
 
@@ -285,6 +414,8 @@ class CacheManager(ConfigMixin, LogMixin, Base):
             "project_id": project_id,
             "project_name": project_name,
             "project_create_time": project_create_time,
+            "translation_project": translation_project,
+            "input_path": input_path,
             "total_line": total_line,
             "line": line,
             "is_complete": total_line > 0 and line >= total_line,
@@ -400,9 +531,17 @@ class CacheManager(ConfigMixin, LogMixin, Base):
         """请求保存缓存。output_path 参数仅保留兼容。"""
         self.save_to_file_require_flag = True
 
+    def flush_pending_save(self) -> None:
+        """立即处理挂起的缓存保存请求。"""
+        if not getattr(self, "save_to_file_require_flag", False):
+            return
+        self.save_to_file()
+        self.save_to_file_require_flag = False
+
     def load_from_project(self, data: CacheProject):
         """直接从内存中的 CacheProject 对象加载项目。"""
         self._ensure_project_metadata(data)
+        self._normalize_project_state(data)
         self.project = data
 
     def load_from_project_id(self, project_id: str) -> None:
@@ -411,6 +550,7 @@ class CacheManager(ConfigMixin, LogMixin, Base):
         with self.file_lock:
             if os.path.isfile(path):
                 self.project = self.read_from_file(path)
+                self._normalize_project_state(self.project)
             else:
                 self.project = None
 
@@ -420,8 +560,101 @@ class CacheManager(ConfigMixin, LogMixin, Base):
         with self.file_lock:
             if os.path.isfile(path):
                 self.project = self.read_from_file(path)
+                self._normalize_project_state(self.project)
             else:
                 self.project = None
+
+    def load_matching_project_cache(self, translation_project: str, input_path: str) -> bool:
+        """加载与当前输入路径和项目类型匹配的项目缓存。"""
+        histories = self.list_project_histories(limit=0, prune=False)
+        for history in histories:
+            project_id = history.get("project_id", "")
+            cache_path = history.get("cache_path", "")
+            if not project_id or not cache_path or not os.path.isfile(cache_path):
+                continue
+
+            try:
+                project = self.read_from_file(cache_path)
+                self._normalize_project_state(project)
+            except Exception as error:
+                self.warning(f"读取项目缓存失败，已跳过: {project_id} - {error}")
+                continue
+
+            if not self._project_matches_source(project, translation_project, input_path):
+                continue
+
+            with self.file_lock:
+                self.project = project
+            return True
+
+        return False
+
+    def prepare_new_project_cache(
+        self,
+        project: CacheProject,
+        translation_project: str,
+        input_path: str,
+    ) -> None:
+        """补齐新读取项目的缓存元数据并载入内存。"""
+        self._ensure_project_metadata(project)
+        self._set_project_cache_metadata(project, translation_project, input_path)
+        self._normalize_project_state(project)
+        self.project = project
+
+    @classmethod
+    def _normalize_project_state(cls, project: CacheProject | None) -> None:
+        if project is None:
+            return
+
+        cls._ensure_project_metadata(project)
+        if project.stats_data is None:
+            project.stats_data = CacheProjectStatistics()
+
+        valid_statuses = {
+            TranslationStatus.UNTRANSLATED,
+            TranslationStatus.TRANSLATED,
+            TranslationStatus.POLISHED,
+            TranslationStatus.EXCLUDED,
+        }
+
+        completed_count = 0
+        for item in project.items_iter():
+            if item.source_text is None:
+                item.source_text = ""
+            elif not isinstance(item.source_text, str):
+                item.source_text = str(item.source_text)
+
+            if item.translated_text is None:
+                item.translated_text = ""
+            elif not isinstance(item.translated_text, str):
+                item.translated_text = str(item.translated_text)
+
+            if item.translation_status not in valid_statuses:
+                item.translation_status = TranslationStatus.UNTRANSLATED
+
+            if item.translation_status in (TranslationStatus.TRANSLATED, TranslationStatus.POLISHED):
+                if not item.translated_text.strip():
+                    item.translation_status = TranslationStatus.UNTRANSLATED
+            elif item.translation_status == TranslationStatus.UNTRANSLATED and item.translated_text.strip():
+                item.translation_status = TranslationStatus.TRANSLATED
+
+            if item.translation_status in (TranslationStatus.TRANSLATED, TranslationStatus.POLISHED):
+                completed_count += 1
+
+        total_count = project.count_items()
+        stats = project.stats_data
+        stats.total_line = max(cls._parse_int(getattr(stats, "total_line", 0)), total_count)
+        stats.line = min(max(cls._parse_int(getattr(stats, "line", 0)), completed_count), stats.total_line)
+        stats.token = max(cls._parse_int(getattr(stats, "token", 0)), 0)
+        stats.total_completion_tokens = max(
+            cls._parse_int(getattr(stats, "total_completion_tokens", 0)),
+            0,
+        )
+        stats.error_requests = max(cls._parse_int(getattr(stats, "error_requests", 0)), 0)
+        stats.total_requests = max(
+            cls._parse_int(getattr(stats, "total_requests", 0)),
+            stats.error_requests,
+        )
 
     @classmethod
     def read_from_file(cls, cache_path) -> CacheProject:
@@ -575,12 +808,174 @@ class CacheManager(ConfigMixin, LogMixin, Base):
 
         return all_items[from_idx:to_idx]
 
+    def _get_item_unit_count(self, item: CacheItem, limit_type: str) -> int:
+        if limit_type == "token":
+            return max(0, item.get_token_count(item.source_text))
+        return 1
+
+    def _get_chunk_unit_count(self, chunk: List[CacheItem], limit_type: str) -> int:
+        if limit_type == "token":
+            return sum(self._get_item_unit_count(item, limit_type) for item in chunk)
+        return len(chunk)
+
+    def _split_items_by_limit(
+        self,
+        items: List[CacheItem],
+        limit_type: str,
+        limit_count: int,
+    ) -> List[List[CacheItem]]:
+        try:
+            limit_count = max(1, int(limit_count))
+        except (TypeError, ValueError):
+            limit_count = 1
+
+        chunks = []
+        current_chunk, current_length = [], 0
+
+        for item in items:
+            item_length = self._get_item_unit_count(item, limit_type)
+            if current_chunk and current_length + item_length > limit_count:
+                chunks.append(current_chunk)
+                current_chunk, current_length = [], 0
+
+            current_chunk.append(item)
+            current_length += item_length
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks
+
+    def _split_prefix_by_min_units(
+        self,
+        items: List[CacheItem],
+        limit_type: str,
+        min_units: int,
+    ) -> tuple[List[CacheItem], List[CacheItem]]:
+        prefix = []
+        prefix_units = 0
+
+        for index, item in enumerate(items):
+            prefix.append(item)
+            prefix_units += self._get_item_unit_count(item, limit_type)
+            if prefix_units >= min_units:
+                return prefix, items[index + 1:]
+
+        return prefix, []
+
+    def _merge_small_tail_chunks(
+        self,
+        chunks: List[List[CacheItem]],
+        limit_type: str,
+        limit_count: int,
+        extra_units: int,
+    ) -> List[List[CacheItem]]:
+        try:
+            limit_count = int(limit_count)
+            extra_units = int(extra_units)
+        except (TypeError, ValueError):
+            return chunks
+
+        if len(chunks) < 2 or limit_count <= 0 or extra_units <= 0:
+            return chunks
+
+        tail_chunk = chunks[-1]
+        tail_units = self._get_chunk_unit_count(tail_chunk, limit_type)
+        if tail_units == 0 or tail_units > extra_units:
+            return chunks
+
+        previous_chunk = chunks[-2]
+        combined_units = (
+            self._get_chunk_unit_count(previous_chunk, limit_type)
+            + tail_units
+        )
+        if combined_units % limit_count == 0:
+            split_chunks = self._split_items_by_limit(
+                previous_chunk + tail_chunk,
+                limit_type,
+                limit_count,
+            )
+            return chunks[:-2] + split_chunks
+
+        if combined_units > limit_count + extra_units:
+            return chunks
+
+        return chunks[:-2] + [previous_chunk + tail_chunk]
+
+    def _optimize_chunks_near_tail(
+        self,
+        chunks: List[List[CacheItem]],
+        limit_type: str,
+        limit_count: int,
+        extra_units: int,
+        mode: str,
+    ) -> List[List[CacheItem]]:
+        try:
+            limit_count = int(limit_count)
+            extra_units = int(extra_units)
+        except (TypeError, ValueError):
+            return chunks
+
+        if len(chunks) < 2 or limit_count <= 0 or extra_units <= 0:
+            return chunks
+
+        mode = str(mode or "off").strip().lower()
+        if mode not in {"dynamic", "tail"}:
+            return chunks
+
+        tail_chunk = chunks[-1]
+        tail_units = self._get_chunk_unit_count(tail_chunk, limit_type)
+        if tail_units == 0:
+            return chunks
+
+        soft_limit = limit_count + extra_units
+
+        if mode == "tail":
+            overflow = tail_units - extra_units
+            if overflow <= 0:
+                return chunks
+
+            previous_chunk = chunks[-2]
+            moved_items, remaining_tail = self._split_prefix_by_min_units(
+                tail_chunk,
+                limit_type,
+                overflow,
+            )
+            if not moved_items or not remaining_tail:
+                return chunks
+
+            previous_units = self._get_chunk_unit_count(previous_chunk, limit_type)
+            moved_units = self._get_chunk_unit_count(moved_items, limit_type)
+            if previous_units + moved_units > soft_limit:
+                return chunks
+
+            return chunks[:-2] + [previous_chunk + moved_items, remaining_tail]
+
+        total_units = sum(self._get_chunk_unit_count(chunk, limit_type) for chunk in chunks)
+        target_chunk_count = len(chunks) - 1
+        if target_chunk_count <= 0 or total_units > target_chunk_count * soft_limit:
+            return chunks
+
+        target_limit = max(1, min(soft_limit, (total_units + target_chunk_count - 1) // target_chunk_count))
+        flat_items = [item for chunk in chunks for item in chunk]
+        optimized_chunks = self._split_items_by_limit(flat_items, limit_type, target_limit)
+
+        if len(optimized_chunks) > target_chunk_count:
+            optimized_chunks = self._split_items_by_limit(flat_items, limit_type, soft_limit)
+
+        if len(optimized_chunks) >= len(chunks):
+            return chunks
+
+        return optimized_chunks
+
     def generate_item_chunks(
         self,
         limit_type: str,
         limit_count: int,
         previous_line_count: int,
         task_mode,
+        chunk_soft_limit_extra_units: int = 0,
+        split_optimization_mode: str = "off",
     ) -> Tuple[List[List[CacheItem]], List[List[CacheItem]], List[str]]:
         """按任务类型和限制条件生成待处理片段。"""
         chunks, previous_chunks, file_paths = [], [], []
@@ -597,32 +992,27 @@ class CacheManager(ConfigMixin, LogMixin, Base):
             if not items:
                 continue
 
-            current_chunk, current_length = [], 0
-            chunk_start_idx_in_filtered_list = 0
+            file_chunks = self._split_items_by_limit(items, limit_type, limit_count)
+            file_chunks = self._optimize_chunks_near_tail(
+                file_chunks,
+                limit_type,
+                limit_count,
+                chunk_soft_limit_extra_units,
+                split_optimization_mode,
+            )
+            file_chunks = self._merge_small_tail_chunks(
+                file_chunks,
+                limit_type,
+                limit_count,
+                chunk_soft_limit_extra_units,
+            )
 
-            for i, item in enumerate(items):
-                item_length = item.get_token_count(item.source_text) if limit_type == "token" else 1
-
-                # 新 chunk 开始时，记录它在筛选后列表中的起始索引
-                if not current_chunk:
-                    chunk_start_idx_in_filtered_list = i
-
-                if current_chunk and (current_length + item_length > limit_count):
-                    chunks.append(current_chunk)
-                    previous_chunks.append(
-                        self.generate_previous_chunks(items, previous_line_count, chunk_start_idx_in_filtered_list)
-                    )
-                    file_paths.append(file.storage_path)
-                    current_chunk, current_length = [], 0
-                    chunk_start_idx_in_filtered_list = i
-
-                current_chunk.append(item)
-                current_length += item_length
-
-            if current_chunk:
+            for current_chunk in file_chunks:
                 chunks.append(current_chunk)
+                first_item_in_chunk = current_chunk[0]
+                real_idx = file.index_of(first_item_in_chunk.text_index)
                 previous_chunks.append(
-                    self.generate_previous_chunks(items, previous_line_count, chunk_start_idx_in_filtered_list)
+                    self.generate_previous_chunks(file.items, previous_line_count, real_idx)
                 )
                 file_paths.append(file.storage_path)
 

--- a/ModuleFolders/Service/TaskExecutor/PolisherTask.py
+++ b/ModuleFolders/Service/TaskExecutor/PolisherTask.py
@@ -153,6 +153,7 @@ class PolisherTask(LogMixin, Base):
                     item.model = self.config.model
                     item.translated_text = response
                     item.translation_status = TranslationStatus.POLISHED
+                    item.clear_manually_reset()
 
             self.print(
                 self.generate_log_table(

--- a/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
+++ b/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
@@ -64,6 +64,26 @@ from ModuleFolders.Infrastructure.RequestLimiter.RequestLimiter import RequestLi
 from ModuleFolders.Service.TaskExecutor.TranslatorUtil import get_source_language_for_file
 
 
+def _safe_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _retry_limit_for_round(initial_limit, current_round, min_limit):
+    current_limit = max(1, _safe_int(initial_limit, 1))
+    min_limit = max(1, _safe_int(min_limit, 1))
+    current_round = max(0, _safe_int(current_round, 0))
+
+    for _ in range(current_round):
+        if current_limit <= min_limit:
+            return current_limit
+        current_limit = max(min_limit, int(current_limit / 2))
+
+    return current_limit
+
+
 # 翻译器
 class TaskExecutor(ConfigMixin, LogMixin, Base):
 
@@ -132,6 +152,55 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
         self.info("简繁转换完成。")
         self.print("")
         return True
+
+    def _get_split_limit_type(self) -> str:
+        return "line" if getattr(self.config, "lines_limit_switch", False) else "token"
+
+    def _get_retry_split_min_limit(self, limit_type: str) -> int:
+        if limit_type == "token":
+            return max(1, _safe_int(getattr(self.config, "retry_split_min_tokens", 100), 100))
+        return max(1, _safe_int(getattr(self.config, "retry_split_min_lines", 15), 15))
+
+    def _get_round_split_limit(self, limit_type: str, current_round: int) -> int:
+        if limit_type == "token":
+            base_limit = getattr(self.config, "tokens_limit", 1024)
+        else:
+            base_limit = getattr(self.config, "lines_limit", 20)
+
+        return _retry_limit_for_round(
+            base_limit,
+            current_round,
+            self._get_retry_split_min_limit(limit_type),
+        )
+
+    def _get_split_optimization_params(self, limit_type: str) -> tuple[int, str]:
+        if not getattr(self.config, "split_optimization_enable", False):
+            return 0, "off"
+
+        if limit_type == "token":
+            extra_units = _safe_int(getattr(self.config, "chunk_soft_limit_extra_tokens", 100), 100)
+        else:
+            extra_units = _safe_int(getattr(self.config, "chunk_soft_limit_extra_lines", 15), 15)
+
+        mode = str(getattr(self.config, "split_optimization_mode", "dynamic") or "dynamic").strip().lower()
+        if mode not in {"dynamic", "tail"}:
+            mode = "dynamic"
+
+        return max(0, extra_units), mode
+
+    def _generate_item_chunks_for_round(self, current_round: int, task_mode: int):
+        limit_type = self._get_split_limit_type()
+        limit_count = self._get_round_split_limit(limit_type, current_round)
+        extra_units, split_optimization_mode = self._get_split_optimization_params(limit_type)
+
+        return self.cache_manager.generate_item_chunks(
+            limit_type,
+            limit_count,
+            self.config.pre_line_counts,
+            task_mode,
+            extra_units,
+            split_optimization_mode,
+        )
 
     # 应用关闭事件
     def app_shut_down(self, event: int, data: dict) -> None:
@@ -364,17 +433,10 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
             if current_round == 0 and continue_status == False:
                 self.project_status_data.total_line = item_count_status_untranslated
 
-            # 第二轮开始对半切分
-            if current_round > 0:
-                self.config.lines_limit = max(1, int(self.config.lines_limit / 2))
-                self.config.tokens_limit = max(1, int(self.config.tokens_limit / 2))
-
             # 生成缓存数据条目片段的合集列表，原文列表与上文列表一一对应
-            chunks, previous_chunks, file_paths = self.cache_manager.generate_item_chunks(
-                "line" if self.config.tokens_limit_switch == False else "token",
-                self.config.lines_limit if self.config.tokens_limit_switch == False else self.config.tokens_limit,
-                self.config.pre_line_counts,
-                TaskType.TRANSLATION
+            chunks, previous_chunks, file_paths = self._generate_item_chunks_for_round(
+                current_round,
+                TaskType.TRANSLATION,
             )
 
             # 生成翻译任务合集列表
@@ -450,7 +512,7 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
                     self._clear_active_executor(executor)
 
         # 等待可能存在的缓存文件写入请求处理完毕
-        time.sleep(CacheManager.SAVE_INTERVAL)
+        self.cache_manager.flush_pending_save()
 
         # 如果开启了转换简繁开关功能，则进行文本转换
         if self.config.response_conversion_toggle:
@@ -553,17 +615,10 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
             if current_round == 0 and continue_status == False:
              self.project_status_data.total_line = item_count_status_unpolishd
 
-            # 第二轮开始对半切分
-            if current_round > 0:
-                self.config.lines_limit = max(1, int(self.config.lines_limit / 2))
-                self.config.tokens_limit = max(1, int(self.config.tokens_limit / 2))
-
             # 生成缓存数据条目片段的合集列表
-            chunks, previous_chunks, file_paths = self.cache_manager.generate_item_chunks(
-                "line" if self.config.tokens_limit_switch == False else "token",
-                self.config.lines_limit if self.config.tokens_limit_switch == False else self.config.tokens_limit,
-                self.config.pre_line_counts,
-                TaskType.POLISH
+            chunks, previous_chunks, file_paths = self._generate_item_chunks_for_round(
+                current_round,
+                TaskType.POLISH,
             )
 
             # 生成润色任务合集列表
@@ -628,7 +683,7 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
                     self._clear_active_executor(executor)
 
         # 等待可能存在的缓存文件写入请求处理完毕
-        time.sleep(CacheManager.SAVE_INTERVAL)
+        self.cache_manager.flush_pending_save()
 
         # 输出配置包
         output_config = {

--- a/ModuleFolders/Service/TaskExecutor/TranslatorTask.py
+++ b/ModuleFolders/Service/TaskExecutor/TranslatorTask.py
@@ -234,6 +234,7 @@ class TranslatorTask(LogMixin, Base):
                     item.model = self.config.model
                     item.translated_text = self.text_symbol_repair.repair_text(self.config, item.source_text, response)
                     item.translation_status = TranslationStatus.TRANSLATED
+                    item.clear_manually_reset()
 
 
             # 打印任务结果

--- a/Resource/Localization/TaskSettings.json
+++ b/Resource/Localization/TaskSettings.json
@@ -48,6 +48,84 @@
       "English": "Tokens per Task",
       "日本語": "タスクあたりのトークン数"
     },
+    "启用尾巴分割优化": {
+      "简中": "启用尾巴分割优化",
+      "繁中": "啟用尾端分割最佳化",
+      "English": "Enable Tail Split Optimization",
+      "日本語": "末尾分割最適化を有効化"
+    },
+    "开启后将按所选模式优化任务末尾过短分片，行数模式与 Token 模式都会生效": {
+      "简中": "开启后将按所选模式优化任务末尾过短分片，行数模式与 Token 模式都会生效",
+      "繁中": "啟用後會依所選模式最佳化任務末尾過短分片，行數模式與 Token 模式都會生效",
+      "English": "Optimize short tail chunks with the selected mode for both Line and Token modes",
+      "日本語": "選択したモードで短い末尾チャンクを最適化し、行数モードとトークンモードの両方に適用します"
+    },
+    "动态分割模式": {
+      "简中": "动态分割模式",
+      "繁中": "動態分割模式",
+      "English": "Dynamic Split Mode",
+      "日本語": "動的分割モード"
+    },
+    "尾巴分割模式": {
+      "简中": "尾巴分割模式",
+      "繁中": "尾端分割模式",
+      "English": "Tail Split Mode",
+      "日本語": "末尾分割モード"
+    },
+    "动态分割会尽量消除末尾小分片，尾巴分割会让最终尾巴落入软上限范围": {
+      "简中": "动态分割会尽量消除末尾小分片，尾巴分割会让最终尾巴落入软上限范围",
+      "繁中": "動態分割會盡量消除末尾小分片，尾端分割會讓最終尾端落入軟上限範圍",
+      "English": "Dynamic mode tries to remove short tail chunks; tail mode keeps the final tail within the soft limit",
+      "日本語": "動的分割は短い末尾チャンクの解消を優先し、末尾分割は最後の末尾をソフト上限内に収めます"
+    },
+    "小尾巴软上限(行)": {
+      "简中": "小尾巴软上限(行)",
+      "繁中": "小尾端軟上限(行)",
+      "English": "Tail Soft Limit (Lines)",
+      "日本語": "末尾ソフト上限(行)"
+    },
+    "行数模式下，允许末尾小分片合并到上一任务的额外行数": {
+      "简中": "行数模式下，允许末尾小分片合并到上一任务的额外行数",
+      "繁中": "行數模式下，允許末尾小分片合併到上一任務的額外行數",
+      "English": "Extra lines allowed when merging a short tail chunk into the previous task in Line mode",
+      "日本語": "行数モードで短い末尾チャンクを前のタスクへ結合するときに許可する追加行数"
+    },
+    "小尾巴软上限(Token)": {
+      "简中": "小尾巴软上限(Token)",
+      "繁中": "小尾端軟上限(Token)",
+      "English": "Tail Soft Limit (Tokens)",
+      "日本語": "末尾ソフト上限(トークン)"
+    },
+    "Token 模式下，允许末尾小分片合并到上一任务的额外 Token 数": {
+      "简中": "Token 模式下，允许末尾小分片合并到上一任务的额外 Token 数",
+      "繁中": "Token 模式下，允許末尾小分片合併到上一任務的額外 Token 數",
+      "English": "Extra tokens allowed when merging a short tail chunk into the previous task in Token mode",
+      "日本語": "トークンモードで短い末尾チャンクを前のタスクへ結合するときに許可する追加トークン数"
+    },
+    "重试最小切分(行)": {
+      "简中": "重试最小切分(行)",
+      "繁中": "重試最小切分(行)",
+      "English": "Retry Minimum Split (Lines)",
+      "日本語": "再試行時の最小分割(行)"
+    },
+    "行数模式下，多轮重试自动缩小分片时不会低于该行数": {
+      "简中": "行数模式下，多轮重试自动缩小分片时不会低于该行数",
+      "繁中": "行數模式下，多輪重試自動縮小分片時不會低於此行數",
+      "English": "In Line mode, retry rounds will not shrink chunks below this line count",
+      "日本語": "行数モードでは、再試行ラウンドでこの行数未満には分割しません"
+    },
+    "重试最小切分(Token)": {
+      "简中": "重试最小切分(Token)",
+      "繁中": "重試最小切分(Token)",
+      "English": "Retry Minimum Split (Tokens)",
+      "日本語": "再試行時の最小分割(トークン)"
+    },
+    "Token 模式下，多轮重试自动缩小分片时不会低于该 Token 数": {
+      "简中": "Token 模式下，多轮重试自动缩小分片时不会低于该 Token 数",
+      "繁中": "Token 模式下，多輪重試自動縮小分片時不會低於此 Token 數",
+      "English": "In Token mode, retry rounds will not shrink chunks below this token count",
+      "日本語": "トークンモードでは、再試行ラウンドでこのトークン数未満には分割しません"
+    },
     "并发任务数": {
       "简中": "并发任务数",
       "繁中": "並行任務數",

--- a/UserInterface/EditView/Startup/StartupPage.py
+++ b/UserInterface/EditView/Startup/StartupPage.py
@@ -214,13 +214,24 @@ class StartupPage(ConfigMixin, LogMixin, ToastMixin, Base, QWidget):
             label_input_exclude_rule = config.get("label_input_exclude_rule", "")
 
             if mode == "new":
-                cache_project = self.file_reader.read_files(
+                cache_reused = self.cache_manager.load_matching_project_cache(
                     translation_project,
                     label_input_path,
-                    label_input_exclude_rule,
                 )
-                self.cache_manager.load_from_project(cache_project)
-                self.cache_manager.save_to_file()
+                if cache_reused:
+                    mode = "continue"
+                else:
+                    cache_project = self.file_reader.read_files(
+                        translation_project,
+                        label_input_path,
+                        label_input_exclude_rule,
+                    )
+                    self.cache_manager.prepare_new_project_cache(
+                        cache_project,
+                        translation_project,
+                        label_input_path,
+                    )
+                    self.cache_manager.save_to_file()
             elif project_id:
                 self.cache_manager.load_from_project_id(project_id)
             else:

--- a/UserInterface/Settings/TaskSettingsPage.py
+++ b/UserInterface/Settings/TaskSettingsPage.py
@@ -1,11 +1,14 @@
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QFrame
+from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QVBoxLayout
-from qfluentwidgets import HorizontalSeparator
+from qfluentwidgets import HorizontalSeparator, SingleDirectionScrollArea
 
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Config.Config import ConfigMixin
 from UserInterface.Widget.SpinCard import SpinCard
 from UserInterface.Widget.ComboBoxCard import ComboBoxCard
+from UserInterface.Widget.SwitchButtonCard import SwitchButtonCard
 
 class TaskSettingsPage(QFrame, ConfigMixin, Base):
 
@@ -17,8 +20,14 @@ class TaskSettingsPage(QFrame, ConfigMixin, Base):
         self.default = {
             "lines_limit_switch": False,
             "tokens_limit_switch": True,
-            "lines_limit": 10,
+            "lines_limit": 20,
             "tokens_limit": 1024,
+            "split_optimization_enable": True,
+            "chunk_soft_limit_extra_lines": 15,
+            "chunk_soft_limit_extra_tokens": 100,
+            "split_optimization_mode": "dynamic",
+            "retry_split_min_lines": 15,
+            "retry_split_min_tokens": 100,
             "user_thread_counts": 0,
             "request_timeout": 120,
             "round_limit": 10,
@@ -27,20 +36,44 @@ class TaskSettingsPage(QFrame, ConfigMixin, Base):
         # 载入并保存默认配置
         config = self.save_config(self.load_config_from_default())
 
+        # 设置主容器
+        self.container = QVBoxLayout(self)
+        self.container.setContentsMargins(0, 0, 0, 0)
+
+        # 设置滚动容器
+        self.scroller = SingleDirectionScrollArea(self, orient=Qt.Vertical)
+        self.scroller.setWidgetResizable(True)
+        self.scroller.setStyleSheet("QScrollArea { border: none; background: transparent; }")
+        self.container.addWidget(self.scroller)
+
         # 设置容器
-        self.vbox = QVBoxLayout(self)
+        self.vbox_parent = QWidget(self)
+        self.vbox_parent.setStyleSheet("QWidget { background: transparent; }")
+        self.vbox = QVBoxLayout(self.vbox_parent)
         self.vbox.setSpacing(8)
         self.vbox.setContentsMargins(24, 24, 24, 24)
+        self.scroller.setWidget(self.vbox_parent)
 
         # 初始化控件引用
         self.lines_limit_card = None
         self.tokens_limit_card = None
+        self.split_optimization_mode_card = None
+        self.chunk_soft_limit_extra_lines_card = None
+        self.chunk_soft_limit_extra_tokens_card = None
+        self.retry_split_min_lines_card = None
+        self.retry_split_min_tokens_card = None
         self.mode_combo_box = None
 
         # 添加控件
         self.add_widget_01(self.vbox, config)
         self.add_widget_02(self.vbox, config)
         self.add_widget_03(self.vbox, config)
+        self.add_widget_split_optimization_enable(self.vbox, config)
+        self.add_widget_split_optimization_mode(self.vbox, config)
+        self.add_widget_chunk_soft_limit_extra_lines(self.vbox, config)
+        self.add_widget_chunk_soft_limit_extra_tokens(self.vbox, config)
+        self.add_widget_retry_split_min_lines(self.vbox, config)
+        self.add_widget_retry_split_min_tokens(self.vbox, config)
         self.vbox.addWidget(HorizontalSeparator())
         self.add_widget_04(self.vbox, config)
         self.vbox.addWidget(HorizontalSeparator())
@@ -55,12 +88,33 @@ class TaskSettingsPage(QFrame, ConfigMixin, Base):
 
     def update_limit_cards_visibility(self, config):
         """根据当前模式更新限制卡片的可见性"""
-        if config["lines_limit_switch"]:
+        line_mode = config["lines_limit_switch"]
+        optimization_enabled = config.get("split_optimization_enable", False)
+
+        if line_mode:
             self.tokens_limit_card.hide()
             self.lines_limit_card.show()
+            self.chunk_soft_limit_extra_tokens_card.hide()
+            self.retry_split_min_tokens_card.hide()
+            self.chunk_soft_limit_extra_lines_card.show()
+            self.retry_split_min_lines_card.show()
         else:
             self.lines_limit_card.hide()
             self.tokens_limit_card.show()
+            self.chunk_soft_limit_extra_lines_card.hide()
+            self.retry_split_min_lines_card.hide()
+            self.chunk_soft_limit_extra_tokens_card.show()
+            self.retry_split_min_tokens_card.show()
+
+        for card in (
+            self.split_optimization_mode_card,
+            self.chunk_soft_limit_extra_lines_card,
+            self.chunk_soft_limit_extra_tokens_card,
+            self.retry_split_min_lines_card,
+            self.retry_split_min_tokens_card,
+        ):
+            if card is not None:
+                card.setEnabled(optimization_enabled)
 
     # 子任务切分模式
     def add_widget_01(self, parent, config) -> None:
@@ -159,6 +213,127 @@ class TaskSettingsPage(QFrame, ConfigMixin, Base):
         )
         parent.addWidget(self.tokens_limit_card)
 
+    def add_widget_split_optimization_enable(self, parent, config) -> None:
+        def init(widget) -> None:
+            widget.set_checked(config.get("split_optimization_enable", False))
+
+        def checked_changed(widget, checked: bool) -> None:
+            config = self.load_config()
+            config["split_optimization_enable"] = checked
+            self.save_config(config)
+            self.update_limit_cards_visibility(config)
+
+        parent.addWidget(
+            SwitchButtonCard(
+                self.tra("启用尾巴分割优化"),
+                self.tra("开启后将按所选模式优化任务末尾过短分片，行数模式与 Token 模式都会生效"),
+                init=init,
+                checked_changed=checked_changed,
+            )
+        )
+
+    def add_widget_split_optimization_mode(self, parent, config) -> None:
+        mode_pairs = [
+            (self.tra("动态分割模式"), "dynamic"),
+            (self.tra("尾巴分割模式"), "tail"),
+        ]
+        translated_pairs = [(display, value) for display, value in mode_pairs]
+
+        def init(widget) -> None:
+            current_config = self.load_config()
+            current_value = current_config.get("split_optimization_mode", "dynamic")
+            if current_value not in {"dynamic", "tail"}:
+                current_value = "dynamic"
+            index = next((i for i, (_, value) in enumerate(translated_pairs) if value == current_value), 0)
+            widget.set_current_index(max(0, index))
+
+        def current_text_changed(widget, text: str) -> None:
+            value = next((value for display, value in translated_pairs if display == text), "dynamic")
+            config = self.load_config()
+            config["split_optimization_mode"] = value
+            self.save_config(config)
+
+        self.split_optimization_mode_card = ComboBoxCard(
+            self.tra("尾巴分割模式"),
+            self.tra("动态分割会尽量消除末尾小分片，尾巴分割会让最终尾巴落入软上限范围"),
+            [display for display, _ in translated_pairs],
+            init=init,
+            current_text_changed=current_text_changed,
+        )
+        parent.addWidget(self.split_optimization_mode_card)
+
+    def add_widget_chunk_soft_limit_extra_lines(self, parent, config) -> None:
+        def init(widget) -> None:
+            widget.set_range(0, 9999999)
+            widget.set_value(config.get("chunk_soft_limit_extra_lines"))
+
+        def value_changed(widget, value: int) -> None:
+            config = self.load_config()
+            config["chunk_soft_limit_extra_lines"] = value
+            self.save_config(config)
+
+        self.chunk_soft_limit_extra_lines_card = SpinCard(
+            self.tra("小尾巴软上限(行)"),
+            self.tra("行数模式下，允许末尾小分片合并到上一任务的额外行数"),
+            init=init,
+            value_changed=value_changed,
+        )
+        parent.addWidget(self.chunk_soft_limit_extra_lines_card)
+
+    def add_widget_chunk_soft_limit_extra_tokens(self, parent, config) -> None:
+        def init(widget) -> None:
+            widget.set_range(0, 9999999)
+            widget.set_value(config.get("chunk_soft_limit_extra_tokens"))
+
+        def value_changed(widget, value: int) -> None:
+            config = self.load_config()
+            config["chunk_soft_limit_extra_tokens"] = value
+            self.save_config(config)
+
+        self.chunk_soft_limit_extra_tokens_card = SpinCard(
+            self.tra("小尾巴软上限(Token)"),
+            self.tra("Token 模式下，允许末尾小分片合并到上一任务的额外 Token 数"),
+            init=init,
+            value_changed=value_changed,
+        )
+        parent.addWidget(self.chunk_soft_limit_extra_tokens_card)
+
+    def add_widget_retry_split_min_lines(self, parent, config) -> None:
+        def init(widget) -> None:
+            widget.set_range(1, 9999999)
+            widget.set_value(config.get("retry_split_min_lines"))
+
+        def value_changed(widget, value: int) -> None:
+            config = self.load_config()
+            config["retry_split_min_lines"] = value
+            self.save_config(config)
+
+        self.retry_split_min_lines_card = SpinCard(
+            self.tra("重试最小切分(行)"),
+            self.tra("行数模式下，多轮重试自动缩小分片时不会低于该行数"),
+            init=init,
+            value_changed=value_changed,
+        )
+        parent.addWidget(self.retry_split_min_lines_card)
+
+    def add_widget_retry_split_min_tokens(self, parent, config) -> None:
+        def init(widget) -> None:
+            widget.set_range(1, 9999999)
+            widget.set_value(config.get("retry_split_min_tokens"))
+
+        def value_changed(widget, value: int) -> None:
+            config = self.load_config()
+            config["retry_split_min_tokens"] = value
+            self.save_config(config)
+
+        self.retry_split_min_tokens_card = SpinCard(
+            self.tra("重试最小切分(Token)"),
+            self.tra("Token 模式下，多轮重试自动缩小分片时不会低于该 Token 数"),
+            init=init,
+            value_changed=value_changed,
+        )
+        parent.addWidget(self.retry_split_min_tokens_card)
+
     # 同时执行的子任务数量
     def add_widget_04(self, parent, config) -> None:
         def init(widget) -> None:
@@ -219,4 +394,3 @@ class TaskSettingsPage(QFrame, ConfigMixin, Base):
                 value_changed = value_changed,
             )
         )
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ google-genai
 tiktoken
 numpy
 openpyxl
-PyQt5
+PyQt5==5.15.11
+PyQt5-Qt5==5.15.2
 PyQt-Fluent-Widgets[full]~=1.10.0
 pyobjc-framework-Cocoa; sys_platform == "darwin"
 opencc


### PR DESCRIPTION
1.现在如果一个批次为 3556，设定的行数分割为50行一批，那么它会在最后一批自动补全剩余的6行尾巴，也就是说最后一批请求是56行（具体阈值可以自己设定，默认10行），避免LLM上下文过短出现翻译异常问题 2.现在给 动态分割模式 和 尾巴分割模式
动态分割模式的逻辑是 临近任务末尾时，每批会少量增加翻译内容，尽量让最终批次正好到达任务终点，减少孤立小批次 尾巴分割模式是 不一定消灭尾巴，而让最终尾巴落入 小尾巴软上限  的范围内
3.最小切分优化
之前的逻辑是只要出现问题就自动对半切分，导致LLM上下文过少翻译错误率增加，现在这个逻辑是它最低可以切分到多少，但也会受 “尾巴范围设置” 影响，也就是说，如果一批是20行，我们假设 自动切分最小阈值为15，但切分后会存在5行的孤立行数，所以它应该受“尾巴范围设置”影响，它不会留下孤立行数，即使最小设定为15，剩下5行的孤立行数依旧会被加入同一个批次，降低翻译错误率

最小切分阈值 刚好可以整除最后的批次，那么不受尾巴影响，比如一批为30，刚好可以被默认的15行整除，那么它不会变成25+5这种批次而是15+15