### PR TITLE
pref/优化生成翻译/润色任务速度

### DIFF
--- a/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
+++ b/ModuleFolders/Domain/PromptBuilder/GlossaryHelper.py
@@ -1,5 +1,9 @@
 import regex
 import regex._regex_core
+from functools import lru_cache
+
+
+_CACHE_MAXSIZE = 8192
 
 
 class GlossaryHelper:
@@ -15,6 +19,7 @@ class GlossaryHelper:
         return str(value).strip()
 
     @staticmethod
+    @lru_cache(maxsize=_CACHE_MAXSIZE)
     def _compile_source_text(source_text: str):
         return regex.compile(source_text)
 
@@ -75,6 +80,7 @@ class GlossaryHelper:
             return False
 
     @classmethod
+    @lru_cache(maxsize=_CACHE_MAXSIZE)
     def is_regex_pattern(cls, source_text: str) -> bool:
         source_text = cls._normalize_text(source_text)
         if not source_text:
@@ -90,6 +96,7 @@ class GlossaryHelper:
         return literal_text != source_text
 
     @classmethod
+    @lru_cache(maxsize=_CACHE_MAXSIZE)
     def get_source_state(cls, source_text: str) -> str:
         source_text = cls._normalize_text(source_text)
         if not source_text:
@@ -158,6 +165,7 @@ class GlossaryHelper:
         return normalized_rows
 
     @classmethod
+    @lru_cache(maxsize=_CACHE_MAXSIZE)
     def build_search_pattern(
         cls,
         source_text: str,
@@ -279,3 +287,10 @@ class GlossaryHelper:
                 seen_keys.add(dedupe_key)
 
         return matched_rows
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        cls._compile_source_text.cache_clear()
+        cls.is_regex_pattern.cache_clear()
+        cls.get_source_state.cache_clear()
+        cls.build_search_pattern.cache_clear()

--- a/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
+++ b/ModuleFolders/Service/TaskExecutor/TaskExecutor.py
@@ -82,6 +82,7 @@ from ModuleFolders.Domain.PromptBuilder.PromptBuilderPolishing import PromptBuil
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderEnum import PromptBuilderEnum
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderLocal import PromptBuilderLocal
 from ModuleFolders.Domain.PromptBuilder.PromptBuilderSakura import PromptBuilderSakura
+from ModuleFolders.Domain.PromptBuilder.GlossaryHelper import GlossaryHelper
 from ModuleFolders.Domain.TextFilter.TextFilter import TextFilter
 from ModuleFolders.Domain.TranslationResultCheck.TranslationResultCheck import TranslationResultCheck
 from ModuleFolders.Infrastructure.LLMRequester.LLMClientFactory import LLMClientFactory
@@ -416,6 +417,7 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
                 task.set_previous_items(previous_chunk)  # 传入该任务待翻译原文的上文
                 task.prepare(self.config.target_platform)  # 预先构建消息列表
                 tasks_list.append(task)
+            GlossaryHelper.clear_cache()
             self.info(f"已经生成全部翻译任务 ...")
             self.print("")
 
@@ -601,6 +603,7 @@ class TaskExecutor(ConfigMixin, LogMixin, Base):
                 task.set_previous_items(previous_chunk)  # 传入该任务待润色文的上文
                 task.prepare()  # 预先构建消息列表
                 tasks_list.append(task)
+            GlossaryHelper.clear_cache()
             self.info(f"已经生成全部润色任务 ...")
             self.print("")
 


### PR DESCRIPTION
GlossaryHelper只加了lru_cache和clear_cache其他为换行符带来的差异（CRLF和LF都会这样，就保持分支拉下来的CRLF了）
#1069 