### PR TITLE
feat: 统一称呼翻译，以角色本名为锚点扫描称呼变体并路由提示词（默认关闭）

### DIFF
--- a/ModuleFolders/Domain/PromptBuilder/CharacterNameHelper.py
+++ b/ModuleFolders/Domain/PromptBuilder/CharacterNameHelper.py
@@ -1,0 +1,128 @@
+import re
+
+from ModuleFolders.Domain.PromptBuilder.CharacterHelper import CharacterHelper
+
+
+class CharacterNameHelper:
+    """
+    角色称呼变体（别名/敬称形式）扫描与路由辅助。
+
+    以已确认的本名（全名）为锚点，在全项目原文中扫描该角色的实际出现形式：
+    - 全名 / 名的单独出现
+    - 全名 / 姓 / 名 + 常见敬称或称呼后缀（先輩、前辈、くん、さん、chan 等）
+
+    用途：把这些称呼变体与对应本名一起注入翻译提示词，并附一致性指令，
+    使模型对同一角色（含敬称）保持统一译名，避免"前辈/学姐"等译法混用。
+    """
+
+    # 常见敬称 / 称呼后缀（按出现场景覆盖日文、中文、英文习惯）。
+    # 匹配时按词干后缀拼接，仅收集原文中真实出现的字符串，因此表宽不影响准确性。
+    HONORIFIC_SUFFIXES = (
+        # 日文习惯
+        "先輩", "先辈", "前辈", "学姐", "学长", "师姐", "师兄",
+        "くん", "君", "さん", "ちゃん", "様", "さま",
+        "先生", "小姐", "同学", "老师", "大人", "桑", "酱",
+        # 英文习惯
+        "chan", "kun", "san", "sama", "senpai", "-chan", "-kun", "-san", "-sama",
+    )
+
+    # 变体去重时忽略的大小写差异
+    _IGNORE_CASE = re.IGNORECASE
+
+    @classmethod
+    def _build_stems(cls, base_name: str) -> list[str]:
+        """
+        根据本名生成匹配词干（正则片段）。
+        - 单部分名字：返回该名字本身。
+        - 多部分名字（含 [Separator]、点、空格分隔）：返回"完整拼接"与"名（最后一部分）"两个词干，
+          例如 远坂[Separator]凛 -> 远坂(?:分隔符)?凛 与 凛。
+        """
+        parts = CharacterHelper.split_name(base_name)
+        if not parts:
+            return []
+
+        stems = []
+        if len(parts) == 1:
+            stems.append(re.escape(parts[0]))
+        else:
+            # 完整名：各部分之间允许出现一个常见的分隔符（点/空格/中点等）
+            full_pattern = re.escape(parts[0])
+            for part in parts[1:]:
+                full_pattern += f"(?:[{re.escape(CharacterHelper.DOT_SEPARATORS + CharacterHelper.SPACE_SEPARATOR)}])?"
+                full_pattern += re.escape(part)
+            stems.append(full_pattern)
+            # 名（最后一部分）常被单独用作称呼
+            stems.append(re.escape(parts[-1]))
+
+        return stems
+
+    @classmethod
+    def _scan_stem(cls, full_text: str, stem: str) -> set[str]:
+        """扫描单个词干（可带可选敬称后缀）在全文中的实际出现形式。"""
+        if not stem or not full_text:
+            return set()
+
+        suffix_pattern = "(?:" + "|".join(re.escape(s) for s in cls.HONORIFIC_SUFFIXES) + ")"
+        # 词干与敬称之间允许至多一个空白，兼容 "Alice senpai" 这类英文习惯写法
+        pattern = re.compile(stem + r"\s?" + suffix_pattern + "?", cls._IGNORE_CASE)
+        found = set(match.group() for match in pattern.finditer(full_text))
+        # 去掉纯空白形式
+        return {text.strip() for text in found if text.strip()}
+
+    @classmethod
+    def collect_variants(cls, full_text: str, base_name: str) -> list[str]:
+        """
+        收集某个本名在全文中的称呼变体（不含本名本身）。
+
+        Args:
+            full_text: 全项目原文拼接文本。
+            base_name: 已确认的本名 / 全名，支持 [Separator] 分隔姓与名。
+
+        Returns:
+            去重后的变体列表（保持扫描顺序）。
+        """
+        if not full_text or not base_name:
+            return []
+
+        stems = cls._build_stems(base_name)
+        collected: set[str] = set()
+        for stem in stems:
+            collected.update(cls._scan_stem(full_text, stem))
+
+        # 排除与本名完全一致的匹配（忽略大小写与空白差异）
+        normalized_base = re.sub(r"\s+", "", base_name)
+        variants = []
+        for text in collected:
+            normalized_text = re.sub(r"\s+", "", text)
+            if normalized_text.lower() == normalized_base.lower():
+                continue
+            if text not in variants:
+                variants.append(text)
+        return variants
+
+    @classmethod
+    def collect_project_variants(cls, full_text: str, anchors: list[dict]) -> dict[str, list[str]]:
+        """
+        对一组本名锚点批量扫描变体。
+
+        Args:
+            full_text: 全项目原文拼接文本。
+            anchors: 锚点行列表，每行需含 "source"（本名），可含 "recommended_translation"。
+
+        Returns:
+            {本名: [变体...]}，仅包含实际扫到变体的本名。
+        """
+        result: dict[str, list[str]] = {}
+        if not full_text:
+            return result
+
+        for anchor in anchors or []:
+            if not isinstance(anchor, dict):
+                continue
+            base_name = str(anchor.get("source", "") or "").strip()
+            if not base_name:
+                continue
+            variants = cls.collect_variants(full_text, base_name)
+            if variants:
+                result[base_name] = variants
+        return result

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilder.py
@@ -605,6 +605,7 @@ class PromptBuilder(Base):
         title_en: str,
         header_zh: str,
         header_en: str,
+        instruction: str = "",
     ) -> str:
         """
         构建通用项目表片段，最终会拼成 markdown 风格的表头加逐行数据。
@@ -617,6 +618,8 @@ class PromptBuilder(Base):
         ###Character Table
         Original Text|Recommended Translation|Gender|Remarks
         Alice|爱丽丝|女性|主角
+
+        instruction 参数非空时，插入到表头之前，用于附加使用规则说明。
         """
         matched_rows = PromptBuilder._match_project_table_rows(
             rows,
@@ -635,9 +638,15 @@ class PromptBuilder(Base):
             return ""
 
         if config.target_language in ("chinese_simplified", "chinese_traditional"):
-            prompt_lines = [f"\n###{title_zh}", header_zh]
+            prompt_lines = [f"\n###{title_zh}"]
+            if instruction:
+                prompt_lines.append(instruction)
+            prompt_lines.append(header_zh)
         else:
-            prompt_lines = [f"\n###{title_en}", header_en]
+            prompt_lines = [f"\n###{title_en}"]
+            if instruction:
+                prompt_lines.append(instruction)
+            prompt_lines.append(header_en)
 
         for row in normalized_rows:
             prompt_lines.append("|".join(row))
@@ -646,7 +655,21 @@ class PromptBuilder(Base):
 
     # 构建角色表
     def build_project_characters_prompt(config: TaskConfig, source_text_dict: dict) -> str:
-        return PromptBuilder._build_project_table_prompt(
+        # 统一称呼翻译开关：默认关闭。关闭时保持旧行为（仅注入角色表，无路由指令与称呼变体小节）
+        if not bool(getattr(config, "character_name_unify_switch", False)):
+            return PromptBuilder._build_project_table_prompt(
+                config,
+                source_text_dict,
+                getattr(config, "project_characters_data", []),
+                "source",
+                ("source", "recommended_translation", "gender", "note"),
+                "角色表",
+                "Character Table",
+                "原文|推荐译名|性别|备注",
+                "Original Text|Recommended Translation|Gender|Remarks",
+            )
+
+        character_prompt = PromptBuilder._build_project_table_prompt(
             config,
             source_text_dict,
             getattr(config, "project_characters_data", []),
@@ -656,7 +679,76 @@ class PromptBuilder(Base):
             "Character Table",
             "原文|推荐译名|性别|备注",
             "Original Text|Recommended Translation|Gender|Remarks",
+            instruction=PromptBuilder._get_character_table_instruction(config),
         )
+        variants_prompt = PromptBuilder._build_character_variants_prompt(config, source_text_dict)
+        if variants_prompt:
+            return character_prompt + variants_prompt
+        return character_prompt
+
+    # 角色表路由指令：强制使用推荐译名，保持全文一致
+    def _get_character_table_instruction(config: TaskConfig) -> str:
+        if config.target_language in ("chinese_simplified", "chinese_traditional"):
+            return (
+                "翻译时，以下角色名必须严格使用「推荐译名」列，不得意译或更改，全文保持一致；"
+                "同一角色的敬称/称呼变体（如 空太先輩、空太くん）必须复用本名的推荐译名。"
+            )
+        return (
+            "When translating, the character names below MUST use the Recommended Translation column exactly; "
+            "do not paraphrase or alter them. Keep them consistent throughout the text; "
+            "honorific/variant forms of the same character (e.g. 空太先輩, 空太くん) must reuse the base name's recommended translation."
+        )
+
+    # 构建角色称呼变体小节：以本名为锚，列出原文中出现的变体（含敬称），并附一致性指令
+    def _build_character_variants_prompt(config: TaskConfig, source_text_dict: dict) -> str:
+        variants_map = getattr(config, "project_character_variants", {}) or {}
+        if not variants_map or not source_text_dict:
+            return ""
+
+        full_text = "\n".join(source_text_dict.values())
+        if not full_text:
+            return ""
+
+        # 本名 -> 推荐译名 查找表
+        translation_by_source = {
+            str(row.get("source", "") or "").strip(): str(row.get("recommended_translation", "") or "").strip()
+            for row in getattr(config, "project_characters_data", []) or []
+            if isinstance(row, dict) and str(row.get("source", "") or "").strip()
+        }
+
+        matched_lines = []
+        for base_name, variants in variants_map.items():
+            recommended = translation_by_source.get(base_name, "")
+            # 只注入当前批次原文中实际出现的变体，控制 token 开销
+            present_variants = [v for v in variants if v in full_text]
+            if not present_variants:
+                continue
+            matched_lines.append((base_name, recommended, present_variants))
+
+        if not matched_lines:
+            return ""
+
+        if config.target_language in ("chinese_simplified", "chinese_traditional"):
+            lines = [
+                "\n###角色称呼变体",
+                "以下称呼均为对应角色的变体（含敬称）。翻译时必须复用本名的推荐译名；"
+                "敬称部分选择一种合理译法后全文保持一致，禁止同一称呼出现多种译法（如「先輩」不得时而「前辈」时而「学姐」）。",
+                "本名|推荐译名|原文称呼变体",
+            ]
+        else:
+            lines = [
+                "\n###Character Name Variants",
+                "The following are variant forms (including honorifics) of the corresponding characters. "
+                "Their translations MUST reuse the recommended translation of the base name. "
+                "Choose ONE consistent rendering for each honorific throughout the whole text; "
+                "never mix translations of the same honorific.",
+                "Base Name|Recommended Translation|Original Name Variants",
+            ]
+
+        for base_name, recommended, present_variants in matched_lines:
+            lines.append(f"{base_name}|{recommended if recommended else ' '}|{'、'.join(present_variants)}")
+
+        return "\n".join(lines)
 
     # 构建术语表
     def build_project_terms_prompt(config: TaskConfig, source_text_dict: dict) -> str:

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderLocal.py
@@ -227,6 +227,7 @@ class PromptBuilderLocal(Base):
         title_en: str,
         header_zh: str,
         header_en: str,
+        instruction: str = "",
     ) -> str:
         matched_rows = PromptBuilderLocal._match_project_table_rows(
             rows,
@@ -245,9 +246,15 @@ class PromptBuilderLocal(Base):
             return ""
 
         if PromptBuilderLocal._is_chinese_target(config):
-            prompt_lines = [f"\n###{title_zh}", header_zh]
+            prompt_lines = [f"\n###{title_zh}"]
+            if instruction:
+                prompt_lines.append(instruction)
+            prompt_lines.append(header_zh)
         else:
-            prompt_lines = [f"\n###{title_en}", header_en]
+            prompt_lines = [f"\n###{title_en}"]
+            if instruction:
+                prompt_lines.append(instruction)
+            prompt_lines.append(header_en)
 
         for row in normalized_rows:
             prompt_lines.append("|".join(row))
@@ -256,7 +263,21 @@ class PromptBuilderLocal(Base):
 
     # 生成项目角色表 - LocalLLM
     def build_project_characters_prompt(config: TaskConfig, source_text_dict: dict) -> str:
-        return PromptBuilderLocal._build_project_table_prompt(
+        # 统一称呼翻译开关：默认关闭。关闭时保持旧行为（仅注入角色表，无路由指令与称呼变体小节）
+        if not bool(getattr(config, "character_name_unify_switch", False)):
+            return PromptBuilderLocal._build_project_table_prompt(
+                config,
+                source_text_dict,
+                getattr(config, "project_characters_data", []),
+                "source",
+                ("source", "recommended_translation", "gender", "note"),
+                "角色表",
+                "Character Table",
+                "原文|推荐译名|性别|备注",
+                "Original Text|Recommended Translation|Gender|Remarks",
+            )
+
+        character_prompt = PromptBuilderLocal._build_project_table_prompt(
             config,
             source_text_dict,
             getattr(config, "project_characters_data", []),
@@ -266,7 +287,74 @@ class PromptBuilderLocal(Base):
             "Character Table",
             "原文|推荐译名|性别|备注",
             "Original Text|Recommended Translation|Gender|Remarks",
+            instruction=PromptBuilderLocal._get_character_table_instruction(config),
         )
+        variants_prompt = PromptBuilderLocal._build_character_variants_prompt(config, source_text_dict)
+        if variants_prompt:
+            return character_prompt + variants_prompt
+        return character_prompt
+
+    # 角色表路由指令：强制使用推荐译名，保持全文一致
+    def _get_character_table_instruction(config: TaskConfig) -> str:
+        if PromptBuilderLocal._is_chinese_target(config):
+            return (
+                "翻译时，以下角色名必须严格使用「推荐译名」列，不得意译或更改，全文保持一致；"
+                "同一角色的敬称/称呼变体（如 空太先輩、空太くん）必须复用本名的推荐译名。"
+            )
+        return (
+            "When translating, the character names below MUST use the Recommended Translation column exactly; "
+            "do not paraphrase or alter them. Keep them consistent throughout the text; "
+            "honorific/variant forms of the same character (e.g. 空太先輩, 空太くん) must reuse the base name's recommended translation."
+        )
+
+    # 构建角色称呼变体小节 - LocalLLM（与通用版一致）
+    def _build_character_variants_prompt(config: TaskConfig, source_text_dict: dict) -> str:
+        variants_map = getattr(config, "project_character_variants", {}) or {}
+        if not variants_map or not source_text_dict:
+            return ""
+
+        full_text = "\n".join(source_text_dict.values())
+        if not full_text:
+            return ""
+
+        translation_by_source = {
+            str(row.get("source", "") or "").strip(): str(row.get("recommended_translation", "") or "").strip()
+            for row in getattr(config, "project_characters_data", []) or []
+            if isinstance(row, dict) and str(row.get("source", "") or "").strip()
+        }
+
+        matched_lines = []
+        for base_name, variants in variants_map.items():
+            recommended = translation_by_source.get(base_name, "")
+            present_variants = [v for v in variants if v in full_text]
+            if not present_variants:
+                continue
+            matched_lines.append((base_name, recommended, present_variants))
+
+        if not matched_lines:
+            return ""
+
+        if PromptBuilderLocal._is_chinese_target(config):
+            lines = [
+                "\n###角色称呼变体",
+                "以下称呼均为对应角色的变体（含敬称）。翻译时必须复用本名的推荐译名；"
+                "敬称部分选择一种合理译法后全文保持一致，禁止同一称呼出现多种译法（如「先輩」不得时而「前辈」时而「学姐」）。",
+                "本名|推荐译名|原文称呼变体",
+            ]
+        else:
+            lines = [
+                "\n###Character Name Variants",
+                "The following are variant forms (including honorifics) of the corresponding characters. "
+                "Their translations MUST reuse the recommended translation of the base name. "
+                "Choose ONE consistent rendering for each honorific throughout the whole text; "
+                "never mix translations of the same honorific.",
+                "Base Name|Recommended Translation|Original Name Variants",
+            ]
+
+        for base_name, recommended, present_variants in matched_lines:
+            lines.append(f"{base_name}|{recommended if recommended else ' '}|{'、'.join(present_variants)}")
+
+        return "\n".join(lines)
 
     # 生成项目术语表 - LocalLLM
     def build_project_terms_prompt(config: TaskConfig, source_text_dict: dict) -> str:

--- a/ModuleFolders/Domain/PromptBuilder/PromptBuilderSakura.py
+++ b/ModuleFolders/Domain/PromptBuilder/PromptBuilderSakura.py
@@ -123,13 +123,53 @@ class PromptBuilderSakura(Base):
 
     # 生成项目角色表 - Sakura
     def build_project_characters_prompt(config: TaskConfig, source_text_dict: dict) -> str:
-        return PromptBuilderSakura._build_project_table_prompt(
+        character_prompt = PromptBuilderSakura._build_project_table_prompt(
             source_text_dict,
             getattr(config, "project_characters_data", []),
             "source",
             "recommended_translation",
             ("gender", "note"),
         )
+        # 统一称呼翻译开关：默认关闭，关闭时仅注入角色表，不注入称呼变体小节
+        if not bool(getattr(config, "character_name_unify_switch", False)):
+            return character_prompt
+        variants_prompt = PromptBuilderSakura._build_character_variants_prompt(config, source_text_dict)
+        if variants_prompt:
+            return character_prompt + variants_prompt
+        return character_prompt
+
+    # 构建角色称呼变体小节 - Sakura（紧凑格式，仅列出变体与本名对应关系）
+    def _build_character_variants_prompt(config: TaskConfig, source_text_dict: dict) -> str:
+        variants_map = getattr(config, "project_character_variants", {}) or {}
+        if not variants_map or not source_text_dict:
+            return ""
+
+        full_text = "\n".join(source_text_dict.values())
+        if not full_text:
+            return ""
+
+        translation_by_source = {
+            str(row.get("source", "") or "").strip(): str(row.get("recommended_translation", "") or "").strip()
+            for row in getattr(config, "project_characters_data", []) or []
+            if isinstance(row, dict) and str(row.get("source", "") or "").strip()
+        }
+
+        matched_lines = []
+        for base_name, variants in variants_map.items():
+            recommended = translation_by_source.get(base_name, "")
+            present_variants = [v for v in variants if v in full_text]
+            if not present_variants:
+                continue
+            matched_lines.append((base_name, recommended, present_variants))
+
+        if not matched_lines:
+            return ""
+
+        lines = ["\n# 角色称呼变体，翻译时必须复用本名译名，同一称呼全文只能一种译法"]
+        for base_name, recommended, present_variants in matched_lines:
+            lines.append(f"{base_name}->{recommended if recommended else base_name} #称呼: {'、'.join(present_variants)}")
+
+        return "\n".join(lines)
 
     # 生成项目术语表 - Sakura
     def build_project_terms_prompt(config: TaskConfig, source_text_dict: dict) -> str:

--- a/ModuleFolders/Infrastructure/TaskConfig/TaskConfig.py
+++ b/ModuleFolders/Infrastructure/TaskConfig/TaskConfig.py
@@ -7,6 +7,7 @@ import rapidjson as json
 from ModuleFolders.Base.Base import Base
 from ModuleFolders.Config.Config import ConfigMixin
 from ModuleFolders.Config.FilePathConfig import auto_output_dir, auto_polish_output_dir, default_polish_output_dir
+from ModuleFolders.Domain.PromptBuilder.CharacterNameHelper import CharacterNameHelper
 from ModuleFolders.Log.Log import LogMixin
 
 
@@ -32,6 +33,8 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
         self.project_characters_data = []
         self.project_terms_data = []
         self.project_non_translate_data = []
+        # 角色称呼变体映射 {本名: [变体...]}，由 load_project_table_data 扫描全项目原文生成
+        self.project_character_variants = {}
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.get_vars()})"
@@ -75,6 +78,7 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
         self.project_characters_data = []
         self.project_terms_data = []
         self.project_non_translate_data = []
+        self.project_character_variants = {}
 
         if cache_manager is None or not hasattr(cache_manager, "get_analysis_data"):
             return
@@ -98,6 +102,38 @@ class TaskConfig(ConfigMixin, LogMixin, Base):
             "marker",
             ("marker", "category", "note"),
         )
+
+        # 以已确认的本名为锚点，扫描全项目原文，收集角色称呼变体（本名+敬称等），
+        # 供 PromptBuilder 注入提示词并附一致性指令，保证同一角色（含敬称）译名统一。
+        # 仅当「统一称呼翻译」开关开启时才扫描，避免无谓开销。
+        if self.project_characters_data and getattr(self, "character_name_unify_switch", False):
+            full_text = self._collect_project_full_text(cache_manager)
+            if full_text:
+                self.project_character_variants = CharacterNameHelper.collect_project_variants(
+                    full_text,
+                    self.project_characters_data,
+                )
+
+    # 拼接全项目原文文本，供称呼变体扫描使用
+    def _collect_project_full_text(self, cache_manager) -> str:
+        try:
+            project = getattr(cache_manager, "project", None)
+            files = getattr(project, "files", None)
+            if not files:
+                return ""
+
+            texts = []
+            for cache_file in files.values():
+                items = getattr(cache_file, "items", None)
+                if not items:
+                    continue
+                for item in items:
+                    source_text = getattr(item, "source_text", "")
+                    if isinstance(source_text, str) and source_text.strip():
+                        texts.append(source_text)
+            return "\n".join(texts)
+        except Exception:
+            return ""
 
     # 规范化接口角色名称，非法值统一回退到 active
     def _normalize_interface_role(self, interface_role: str | None) -> str:

--- a/Resource/Localization/AdvancedSettings.json
+++ b/Resource/Localization/AdvancedSettings.json
@@ -132,6 +132,18 @@
       "English": "Automatically Repair Punctuation",
       "日本語": "句読点を自動修復"
     },
+    "统一称呼翻译": {
+      "简中": "统一称呼翻译",
+      "繁中": "統一稱呼翻譯",
+      "English": "Unify Character Name Translations",
+      "日本語": "呼称翻訳の統一"
+    },
+    "默认关闭，可在本设置中手动开启。开启后，将以角色表中的本名为锚点，扫描全项目原文中的称呼变体（本名+敬称，如 空太先輩、空太くん），并在翻译提示词中要求同一角色（含敬称）必须复用本名推荐译名、同一称呼全文只能使用一种译法，避免「前辈/学姐」等译法混用。": {
+      "简中": "默认关闭，可在本设置中手动开启。开启后，将以角色表中的本名为锚点，扫描全项目原文中的称呼变体（本名+敬称，如 空太先輩、空太くん），并在翻译提示词中要求同一角色（含敬称）必须复用本名推荐译名、同一称呼全文只能使用一种译法，避免「前辈/学姐」等译法混用。",
+      "繁中": "預設關閉，可在本設定中手動開啟。開啟後，將以角色表中的本名為錨點，掃描全專案原文中的稱呼變體（本名+敬稱，如 空太先輩、空太くん），並在翻譯提示詞中要求同一角色（含敬稱）必須複用本名推薦譯名、同一稱呼全文只能使用一種譯法，避免「前輩/學姐」等譯法混用。",
+      "English": "Off by default; enable it here if needed. When enabled, uses the base names in the character table as anchors, scans the whole project for name variants (base name + honorific, e.g. 空太先輩, 空太くん), and instructs the translation prompt that every form of the same character must reuse the base name's recommended translation, with one consistent rendering per honorific throughout the whole text, avoiding mixed renderings like 前辈/学姐.",
+      "日本語": "デフォルトではオフです。必要な場合はこの設定で手動でオンにします。有効にすると、キャラクター表の本名を基準に、プロジェクト全体の原文から呼称バリアント（本名+敬称、例: 空太先輩、空太くん）をスキャンし、翻訳プロンプトで同じキャラクター（敬称を含む）が本名の推奨訳を必ず使い、同じ呼称は本文全体で一つの訳に統一するよう指示します。「先輩/先輩」のような混在訳を防ぎます。"
+    },
     "启用后，将在翻译任务中根据原文恢复译文中改变的标点符号和文本符号，适合日语翻译流程。": {
       "简中": "启用后，将在翻译任务中根据原文恢复译文中改变的标点符号和文本符号，适合日语翻译流程。",
       "繁中": "啟用後，將在翻譯任務中根據原文恢復譯文中改變的標點符號和文本符號，適合日語翻譯流程。",

--- a/UserInterface/PromptSettings/TranslationSettings/TranslationSettingsPage.py
+++ b/UserInterface/PromptSettings/TranslationSettings/TranslationSettingsPage.py
@@ -27,6 +27,7 @@ class TranslationSettingsPage(QFrame, ConfigMixin, Base):
             "few_shot_and_example_switch": True,
             "auto_process_text_code_segment": False,
             "text_symbol_repair_switch": False,
+            "character_name_unify_switch": False,
             "response_check_switch": {
                 "return_to_original_text_check": True,
                 "residual_original_text_check": True,
@@ -48,6 +49,7 @@ class TranslationSettingsPage(QFrame, ConfigMixin, Base):
         self.container.addWidget(HorizontalSeparator())
         self.add_auto_process_text_code_segment(self.container, config)
         self.add_widget_text_symbol_repair(self.container, config)
+        self.add_widget_character_name_unify(self.container, config)
         self.add_widget_language_filter(self.container, config)
         self.add_widget_code_filter(self.container, config)
         self.add_widget_few_shot_and_example(self.container, config)
@@ -173,6 +175,25 @@ class TranslationSettingsPage(QFrame, ConfigMixin, Base):
             SwitchButtonCard(
                 self.tra("自动修复标点符号"),
                 self.tra("启用后，将在翻译任务中根据原文恢复译文中改变的标点符号和文本符号，适合日语翻译流程。"),
+                widget_init,
+                widget_callback,
+            )
+        )
+
+    # 统一称呼翻译（默认关闭）
+    def add_widget_character_name_unify(self, parent, config) -> None:
+        def widget_init(widget) -> None:
+            widget.set_checked(config.get("character_name_unify_switch", False))
+
+        def widget_callback(widget, checked: bool) -> None:
+            config = self.load_config()
+            config["character_name_unify_switch"] = checked
+            self.save_config(config)
+
+        parent.addWidget(
+            SwitchButtonCard(
+                self.tra("统一称呼翻译"),
+                self.tra("默认关闭，可在本设置中手动开启。开启后，将以角色表中的本名为锚点，扫描全项目原文中的称呼变体（本名+敬称，如 空太先輩、空太くん），并在翻译提示词中要求同一角色（含敬称）必须复用本名推荐译名、同一称呼全文只能使用一种译法，避免「前辈/学姐」等译法混用。"),
                 widget_init,
                 widget_callback,
             )

--- a/tests/test_character_name.py
+++ b/tests/test_character_name.py
@@ -1,0 +1,207 @@
+"""
+角色称呼变体（本名+敬称）扫描与提示词路由测试。
+
+运行：.venv/bin/python tests/test_character_name.py
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ModuleFolders.Domain.PromptBuilder.CharacterHelper import CharacterHelper
+from ModuleFolders.Domain.PromptBuilder.CharacterNameHelper import CharacterNameHelper
+from ModuleFolders.Domain.PromptBuilder.PromptBuilder import PromptBuilder
+from ModuleFolders.Domain.PromptBuilder.PromptBuilderLocal import PromptBuilderLocal
+from ModuleFolders.Domain.PromptBuilder.PromptBuilderSakura import PromptBuilderSakura
+from ModuleFolders.Domain.PromptBuilder.PromptBuilderPolishing import PromptBuilderPolishing
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = ""):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  [PASS] {name}")
+    else:
+        FAIL += 1
+        print(f"  [FAIL] {name} {detail}")
+
+
+def make_config(target_language="chinese_simplified", unify_switch=True):
+    """构造最小 TaskConfig 替身（SimpleNamespace），避免依赖完整配置。"""
+    from types import SimpleNamespace
+    config = SimpleNamespace(
+        target_language=target_language,
+        character_name_unify_switch=unify_switch,
+        project_characters_data=[
+            {"source": "空太", "recommended_translation": "空太", "gender": "男性", "note": "主角"},
+            {"source": "远坂[Separator]凛", "recommended_translation": "远坂凛", "gender": "女性", "note": "女主角"},
+            {"source": "Alice", "recommended_translation": "爱丽丝", "gender": "女性", "note": ""},
+        ],
+        project_terms_data=[],
+        project_non_translate_data=[],
+        project_character_variants={},
+    )
+    return config
+
+
+# ========================================================================
+# 1. 变体扫描
+# ========================================================================
+print("== 变体扫描 collect_variants ==")
+
+full_text = (
+    "空太先輩、空太くん、空太君はここにいる。\n"
+    "空太さんも来た。\n"
+    "远坂凛先輩が笑った。\n"
+    "凛ちゃん、凛さんも一緒だ。\n"
+    "Alice senpai, Alice-san, Alice-chan."
+)
+
+variants = CharacterNameHelper.collect_variants(full_text, "空太")
+check("空太 扫出 空太先輩", "空太先輩" in variants, str(variants))
+check("空太 扫出 空太くん", "空太くん" in variants, str(variants))
+check("空太 扫出 空太君", "空太君" in variants, str(variants))
+check("空太 扫出 空太さん", "空太さん" in variants, str(variants))
+check("空太 不含本名自身", "空太" not in variants, str(variants))
+
+variants_l = CharacterNameHelper.collect_variants(full_text, "远坂[Separator]凛")
+check("远坂凛 扫出 远坂凛先輩", "远坂凛先輩" in variants_l, str(variants_l))
+check("远坂凛 扫出 凛ちゃん", "凛ちゃん" in variants_l, str(variants_l))
+check("远坂凛 扫出 凛さん", "凛さん" in variants_l, str(variants_l))
+
+variants_a = CharacterNameHelper.collect_variants(full_text, "Alice")
+check("Alice 扫出 Alice senpai", "Alice senpai" in variants_a, str(variants_a))
+check("Alice 扫出 Alice-san", "Alice-san" in variants_a, str(variants_a))
+check("Alice 扫出 Alice-chan", "Alice-chan" in variants_a, str(variants_a))
+
+check("空文本返回空", CharacterNameHelper.collect_variants("", "空太") == [])
+check("空本名返回空", CharacterNameHelper.collect_variants(full_text, "") == [])
+
+# 大小写不敏感
+variants_case = CharacterNameHelper.collect_variants("alice SENPAI です", "Alice")
+check("大小写不敏感 (alice SENPAI)", "alice SENPAI" in variants_case, str(variants_case))
+
+# 无命中
+check("无变体时返回空", CharacterNameHelper.collect_variants("全く別の文章", "空太") == [])
+
+# 批量扫描
+anchors = [
+    {"source": "空太", "recommended_translation": "空太"},
+    {"source": "Alice", "recommended_translation": "爱丽丝"},
+]
+project_variants = CharacterNameHelper.collect_project_variants(full_text, anchors)
+check("批量扫描含 空太", "空太" in project_variants, str(project_variants))
+check("批量扫描含 Alice", "Alice" in project_variants, str(project_variants))
+check("批量扫描不含未出现角色", "远坂[Separator]凛" not in project_variants, str(project_variants))
+check("批量扫描变体非空", bool(project_variants.get("空太")), str(project_variants))
+
+# 敬称被吞进名字的场景：source 为 露娜小姐 时，正文单独出现 露娜 不匹配
+variants_n = CharacterNameHelper.collect_variants("露娜が来た", "露娜小姐")
+check("含敬称 source 不误配纯本名", variants_n == [], str(variants_n))
+
+
+# ========================================================================
+# 2. 提示词构建：通用版
+# ========================================================================
+print("== 通用版 PromptBuilder 提示词 ==")
+
+config = make_config()
+config.project_character_variants = {
+    "空太": ["空太先輩", "空太くん", "空太君"],
+    "Alice": ["Alice senpai"],
+}
+
+source_dict = {
+    "0": "空太先輩が来た。空太くんも。空太君も。",
+    "1": "Alice senpai は元気。",
+}
+
+character_prompt = PromptBuilder.build_project_characters_prompt(config, source_dict)
+check("通用版含角色表标题", "###角色表" in character_prompt)
+check("通用版含路由指令", "推荐译名" in character_prompt and "全文保持一致" in character_prompt)
+check("通用版含变体小节标题", "###角色称呼变体" in character_prompt)
+check("通用版变体含本名行", "空太|空太|空太先輩、空太くん、空太君" in character_prompt, character_prompt)
+check("通用版变体含 Alice 行", "Alice|爱丽丝|Alice senpai" in character_prompt, character_prompt)
+check("通用版本名行仍在", "空太|空太|男性|主角" in character_prompt, character_prompt)
+
+# 当前批次未出现的变体不注入
+source_dict_no_variant = {"0": "空太だけの話"}
+character_prompt_no = PromptBuilder.build_project_characters_prompt(config, source_dict_no_variant)
+check("变体未出现在批次时不注入变体小节", "###角色称呼变体" not in character_prompt_no, character_prompt_no)
+
+# 无角色表时为空
+config_no_char = make_config()
+config_no_char.project_characters_data = []
+config_no_char.project_character_variants = {}
+empty = PromptBuilder.build_project_characters_prompt(config_no_char, source_dict)
+check("无角色表返回空", empty == "", repr(empty))
+
+# 英文目标语言
+config_en = make_config(target_language="english")
+config_en.project_character_variants = {"Alice": ["Alice senpai"]}
+character_prompt_en = PromptBuilder.build_project_characters_prompt(config_en, source_dict)
+check("英文版含 Character Table", "###Character Table" in character_prompt_en)
+check("英文版含 Character Name Variants", "###Character Name Variants" in character_prompt_en)
+check("英文版含英文指令", "MUST use the Recommended Translation" in character_prompt_en)
+
+
+# ========================================================================
+# 3. 提示词构建：Local / Sakura / Polishing
+# ========================================================================
+print("== Local / Sakura / Polishing ==")
+
+local_prompt = PromptBuilderLocal.build_project_characters_prompt(config, source_dict)
+check("Local 版含变体小节", "###角色称呼变体" in local_prompt, local_prompt)
+check("Local 版含路由指令", "推荐译名" in local_prompt)
+
+sakura_prompt = PromptBuilderSakura.build_project_characters_prompt(config, source_dict)
+check("Sakura 版含变体说明", "角色称呼变体" in sakura_prompt, sakura_prompt)
+check("Sakura 版含变体对应", "空太->空太 #称呼: 空太先輩、空太くん、空太君" in sakura_prompt, sakura_prompt)
+
+polishing_prompt = PromptBuilderPolishing.build_project_characters_prompt(config, source_dict)
+check("Polishing 委托通用版含变体小节", "###角色称呼变体" in polishing_prompt, polishing_prompt)
+
+
+# ========================================================================
+# 3.5 统一称呼翻译开关（默认关闭）
+# ========================================================================
+print("== 统一称呼翻译开关 ==")
+
+config_off = make_config(unify_switch=False)
+config_off.project_character_variants = {
+    "空太": ["空太先輩", "空太くん", "空太君"],
+}
+prompt_off = PromptBuilder.build_project_characters_prompt(config_off, source_dict)
+check("关闭时仍注入角色表", "###角色表" in prompt_off, prompt_off)
+check("关闭时不注入路由指令", "推荐译名」列，不得意译" not in prompt_off, prompt_off)
+check("关闭时不注入变体小节", "###角色称呼变体" not in prompt_off, prompt_off)
+check("关闭时不注入一致性指令", "前辈" not in prompt_off and "学姐" not in prompt_off, prompt_off)
+
+prompt_local_off = PromptBuilderLocal.build_project_characters_prompt(config_off, source_dict)
+check("Local 关闭时不注入变体小节", "###角色称呼变体" not in prompt_local_off, prompt_local_off)
+
+prompt_sakura_off = PromptBuilderSakura.build_project_characters_prompt(config_off, source_dict)
+check("Sakura 关闭时不注入变体说明", "角色称呼变体" not in prompt_sakura_off, prompt_sakura_off)
+
+config_no_switch = make_config()
+del config_no_switch.character_name_unify_switch
+config_no_switch.project_character_variants = {"空太": ["空太先輩"]}
+prompt_no_switch = PromptBuilder.build_project_characters_prompt(config_no_switch, source_dict)
+check("无开关字段时按关闭处理", "###角色称呼变体" not in prompt_no_switch, prompt_no_switch)
+
+
+# ========================================================================
+# 4. CharacterHelper 兼容性
+# ========================================================================
+print("== CharacterHelper 兼容 ==")
+
+check("split_name 处理 [Separator]", CharacterHelper.split_name("远坂[Separator]凛") == ["远坂", "凛"])
+check("validate_name 允许普通名字", CharacterHelper.validate_name("空太") is True)
+check("match_original_name 子串匹配", CharacterHelper.match_original_name("空太", "空太先輩が来た") == "空太")
+
+
+print(f"\n结果: {PASS} 通过, {FAIL} 失败")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## 背景

**对应问题：角色译名不一致** —— 同一角色在全文中的称呼（含敬称）经常出现多种译法，最典型的是「先輩」时而译「前辈」、时而译「学姐」，非常影响阅读体验。

现有能力只能覆盖"本名"：角色表可以约束 `空太 → 空太`，但当正文里出现 `空太先輩`、`空太くん` 这类**称呼变体**时，模型无法把它们与角色表里的本名关联，于是每个变体独立发挥，译名随之漂移。角色介绍（角色设定）也只在手动开启且逐条填写时才生效，且同样不处理称呼变体。

## 改动内容

### 1. 本名锚点 + 称呼变体扫描（`CharacterNameHelper`）
以角色表中的 `source`（本名/全名）为锚点，扫描**全项目原文**，收集该角色实际出现的称呼变体（本名+敬称，如 空太先輩、空太くん、Alice senpai）。支持：
- `[Separator]` 分姓/名（远坂[Separator]凛 → 远坂凛先輩、凛ちゃん、凛さん）
- 大小写不敏感（Alice / alice）
- 词干与敬称之间允许一个空格（"Alice senpai" 这类英文习惯写法）
- 敬称表覆盖中/日/英常见称呼（先輩/前辈/学姐/学长/くん/さん/ちゃん/様/君/san/senpai/chan 等）

### 2. 提示词路由（角色表指令 + 「角色称呼变体」小节）
开启开关后，角色表注入路由指令，并新增「角色称呼变体」小节：

```
本名|推荐译名|原文称呼变体
空太|空太|空太先輩、空太くん、空太君
```

明确告诉模型：这些称呼都是同一人，**必须复用本名推荐译名**；同一称呼（含敬称）**全文只能使用一种译法**，从根源上消除「前辈/学姐」并存。

通用 / LocalLLM / Sakura 三套提示词均覆盖（润色委托通用版，自动生效）。

### 3. 翻译设置新增「统一称呼翻译」开关，**默认关闭**
关闭时完全保持旧行为：不注入指令、不注入变体小节，且**不做全文扫描**，零额外开销。

## 设计取舍

- **为什么默认关闭**：作为可选增强，不改变任何现有用户的翻译结果；需要时手动开启。
- **为什么不硬编码敬称译法**：`さん` 译「先生/小姐/同学」取决于语境与人物关系，预设映射反而可能出错。本功能只做**身份绑定 + 全文一致**约束，具体译法交给模型按语境决定，但一旦确定必须全篇统一。
- **为什么不做译后自动替换**：人名替换易误伤且可能破坏游戏资源（维护者此前明确担心过 name 字段被改导致游戏出错），因此本功能只影响提示词，不做任何后处理替换。
- **不改变任何数据存取结构**：角色表/术语表字段不变，旧项目配置直接可用。

## 测试

测试已提交进仓库：`tests/test_character_name.py`（零第三方依赖，`.venv/bin/python tests/test_character_name.py` 即可运行），共 46 项断言：
- 变体扫描：敬称组合 / `[Separator]` 分姓名 / 大小写不敏感 / 空格分隔 / 不含本名自身 / 无命中
- 提示词构建：通用 / Local / Sakura / 润色 四种提示词的路由指令与变体小节
- 开关行为：默认关闭不注入、无开关字段按关闭处理、开启后注入
- 中英双语输出

回归：`tests/test_text_symbol_repair.py` 67/67 通过；设置页开关默认关闭验证通过；真实 TaskConfig 链路集成验证通过（关→不扫描，开→注入）。

## 提交列表
- `5e31825` feat: 统一称呼翻译功能，以角色本名为锚点扫描称呼变体并路由提示词（默认关闭）
